### PR TITLE
Workflows/refactor name nr quickstart typescript

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,10 +28,10 @@ jobs:
         dir: [backend, frontend]
         include:
           - dir: backend
-            sonar_projectKey: bcgov_nr-quickstart-typescript_backend
+            sonar_projectKey: bcgov_onroutebc_backend
             token: SONAR_TOKEN_BACKEND
           - dir: frontend
-            sonar_projectKey: bcgov_nr-quickstart-typescript_frontend
+            sonar_projectKey: bcgov_onroutebc_frontend
             token: SONAR_TOKEN_FRONTEND
     steps:
       - uses: bcgov-nr/action-test-and-analyse@v0.0.1

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 <!-- PROJECT SHIELDS -->
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_nr-quickstart-typescript&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=bcgov_nr-quickstart-typescript)
-[![Merge to Main](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml/badge.svg)](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)
-[![Unit Tests and Analysis](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/unit-tests.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_onroutebc&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=bcgov_onroutebc)
+[![Merge to Main](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml/badge.svg)](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)
+[![Unit Tests and Analysis](https://github.com/bcgov/onroutebc/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/bcgov/onroutebc/actions/workflows/unit-tests.yml)
 
-[![Issues](https://img.shields.io/github/issues/bcgov/nr-quickstart-typescript)](/../../issues)
-[![Pull Requests](https://img.shields.io/github/issues-pr/bcgov/nr-quickstart-typescript)](/../../pulls)
-[![MIT License](https://img.shields.io/github/license/bcgov/nr-quickstart-typescript.svg)](/LICENSE.md)
+[![Issues](https://img.shields.io/github/issues/bcgov/onroutebc)](/../../issues)
+[![Pull Requests](https://img.shields.io/github/issues-pr/bcgov/onroutebc)](/../../pulls)
+[![MIT License](https://img.shields.io/github/license/bcgov/onroutebc.svg)](/LICENSE.md)
 [![Lifecycle](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
 
 # QuickStart: OpenShift, TypeScript and Postgres/PostGIS
 
-The DevOps Quickstart is a fully functional set of pipeline workflows and a starter application stack intended to help Agile DevOps teams hit the ground running.  Currently OpenShift is supported with plans for AWS (Amazon Web Services).  Pipelines are run using [GitHub Actions](https://github.com/bcgov/nr-quickstart-typescript/actions).
+The DevOps Quickstart is a fully functional set of pipeline workflows and a starter application stack intended to help Agile DevOps teams hit the ground running.  Currently OpenShift is supported with plans for AWS (Amazon Web Services).  Pipelines are run using [GitHub Actions](https://github.com/bcgov/onroutebc/actions).
 
 Features:
 * Pull Request-based pipeline
@@ -114,7 +114,7 @@ The following are required:
 
 Create a new repository using this repository as a template.
 
-* Select bcgov/nr-quickstart-typescript under Repository template
+* Select bcgov/onroutebc under Repository template
 * Check Codecov | Code Coverage to grant access
 * Jira cannot be unchecked (I try every time!)
 
@@ -213,7 +213,7 @@ Pull Requests:
 
 Packages are available from your repository (link on right).  All should have visibility set to public for the workflows to run successfully.
 
-E.g. https://github.com/bcgov/nr-quickstart-typescript/packages
+E.g. https://github.com/bcgov/onroutebc/packages
 
 ### Branch Protection
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,4 @@ This product currently has no support and is experimental.  That could change in
 
 ## Reporting a Vulnerability
 
-Please report any issues or vulerabilities with an [issue](https://github.com/bcgov/nr-quickstart-typescript/issues).
+Please report any issues or vulerabilities with an [issue](https://github.com/bcgov/onroutebc/issues).

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -6,7 +6,7 @@ labels:
 parameters:
   - name: NAME
     description: Module name
-    value: nr-quickstart-typescript
+    value: onroutebc
   - name: COMPONENT
     description: Component name
     value: backend
@@ -37,7 +37,7 @@ parameters:
     value: ghcr.io
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-quickstart-typescript:prod-backend
+    value: bcgov/onroutebc:prod-backend
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nr-quickstart-typescript",
+  "name": "onroutebc",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nr-quickstart-typescript",
+      "name": "onroutebc",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nr-quickstart-typescript",
+  "name": "onroutebc",
   "version": "0.0.1",
   "description": "BCGov devops quickstart. For reference, testing and new projects.",
   "main": "index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bcgov/nr-quickstart-typescript.git"
+    "url": "git+https://github.com/bcgov/onroutebc.git"
   },
   "keywords": [
     "openshift",
@@ -36,9 +36,9 @@
   "author": "Derek Roberts",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/bcgov/nr-quickstart-typescript/issues"
+    "url": "https://github.com/bcgov/onroutebc/issues"
   },
-  "homepage": "https://github.com/bcgov/nr-quickstart-typescript#readme",
+  "homepage": "https://github.com/bcgov/onroutebc#readme",
   "dependencies": {
     "@nestjs/cli": "^9.1.5",
     "@nestjs/common": "^8.4.6",

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello CBerg!!"', () => {
-      expect(appController.getHello()).toBe('Hello CBerg!!');
+    it('should return "Hello World!"', () => {
+      expect(appController.getHello()).toBe('Hello World!');
     });
   });
 });

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello CBerg!"', () => {
-      expect(appController.getHello()).toBe('Hello CBerg!');
+    it('should return "Hello CBerg!!"', () => {
+      expect(appController.getHello()).toBe('Hello CBerg!!');
     });
   });
 });

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello Backend!"', () => {
-      expect(appController.getHello()).toBe('Hello Backend!');
+    it('should return "Hello CBerg!"', () => {
+      expect(appController.getHello()).toBe('Hello CBerg!');
     });
   });
 });

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from "@nestjs/common";
 @Injectable()
 export class AppService {
   getHello(): string {
-    return "Hello CBerg!!";
+    return "Hello World!";
   }
 }

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from "@nestjs/common";
 @Injectable()
 export class AppService {
   getHello(): string {
-    return "Hello Backend!";
+    return "Hello CBerg!";
   }
 }

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from "@nestjs/common";
 @Injectable()
 export class AppService {
   getHello(): string {
-    return "Hello CBerg!";
+    return "Hello CBerg!!";
   }
 }

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello Backend!'))
+    .expect('Hello CBerg!'))
 })

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello CBerg!!'))
+    .expect('Hello World!'))
 })

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello CBerg!'))
+    .expect('Hello CBerg!!'))
 })

--- a/common/openshift.init.yml
+++ b/common/openshift.init.yml
@@ -3,7 +3,7 @@ kind: Template
 parameters:
   - name: NAME
     description: Product name
-    value: nr-quickstart-typescript
+    value: onroutebc
   - name: PG_DATABASE
     description: Postgres database name
     value: database

--- a/database/openshift.deploy.yml
+++ b/database/openshift.deploy.yml
@@ -3,7 +3,7 @@ kind: Template
 parameters:
   - name: NAME
     description: Product name
-    value: nr-quickstart-typescript
+    value: onroutebc
   - name: COMPONENT
     description: Component name
     value: database

--- a/database/templates/openshift.deploy.yml
+++ b/database/templates/openshift.deploy.yml
@@ -3,7 +3,7 @@ kind: Template
 parameters:
   - name: NAME
     description: Product name
-    value: nr-quickstart-typescript
+    value: onroutebc
   - name: COMPONENT
     description: Component name
     value: database

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -6,7 +6,7 @@ labels:
 parameters:
   - name: NAME
     description: Module name
-    value: nr-quickstart-typescript
+    value: onroutebc
   - name: COMPONENT
     description: Component name
     value: frontend
@@ -37,7 +37,7 @@ parameters:
     value: ghcr.io
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
-    value: bcgov/nr-quickstart-typescript:prod-frontend
+    value: bcgov/onroutebc:prod-frontend
 objects:
   - apiVersion: v1
     kind: ImageStream

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nr-quickstart-typescript",
+  "name": "onroutebc",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "nr-quickstart-typescript",
+      "name": "onroutebc",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nr-quickstart-typescript",
+  "name": "onroutebc",
   "version": "0.0.1",
   "description": "BCGov devops quickstart template. For reference, testing and new projects.",
   "main": "index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bcgov/nr-quickstart-typescript.git"
+    "url": "git+https://github.com/bcgov/onroutebc.git"
   },
   "keywords": [
     "openshift",
@@ -36,9 +36,9 @@
   "author": "Derek Roberts",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/bcgov/nr-quickstart-typescript/issues"
+    "url": "https://github.com/bcgov/onroutebc/issues"
   },
-  "homepage": "https://github.com/bcgov/nr-quickstart-typescript#readme",
+  "homepage": "https://github.com/bcgov/onroutebc#readme",
   "dependencies": {
     "@nestjs/cli": "^9.1.5",
     "@nestjs/common": "^8.4.6",

--- a/frontend/src/app.controller.spec.ts
+++ b/frontend/src/app.controller.spec.ts
@@ -13,9 +13,9 @@ describe('AppController', () => {
   })
 
   describe('getHello', () => {
-    it('should return "Hello CBerg!!"', () => {
+    it('should return "Hello World!"', () => {
       const appController = app.get<AppController>(AppController)
-      expect(appController.getHello()).toBe('Hello CBerg!!')
+      expect(appController.getHello()).toBe('Hello World!')
     })
   })
 })

--- a/frontend/src/app.controller.spec.ts
+++ b/frontend/src/app.controller.spec.ts
@@ -13,9 +13,9 @@ describe('AppController', () => {
   })
 
   describe('getHello', () => {
-    it('should return "Hello CBerg!"', () => {
+    it('should return "Hello CBerg!!"', () => {
       const appController = app.get<AppController>(AppController)
-      expect(appController.getHello()).toBe('Hello CBerg!')
+      expect(appController.getHello()).toBe('Hello CBerg!!')
     })
   })
 })

--- a/frontend/src/app.controller.spec.ts
+++ b/frontend/src/app.controller.spec.ts
@@ -13,9 +13,9 @@ describe('AppController', () => {
   })
 
   describe('getHello', () => {
-    it('should return "Hello Frontend!"', () => {
+    it('should return "Hello CBerg!"', () => {
       const appController = app.get<AppController>(AppController)
-      expect(appController.getHello()).toBe('Hello Frontend!')
+      expect(appController.getHello()).toBe('Hello CBerg!')
     })
   })
 })

--- a/frontend/src/app.service.ts
+++ b/frontend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class AppService {
   getHello (): string {
-    return 'Hello Frontend!'
+    return 'Hello CBerg!'
   }
 }

--- a/frontend/src/app.service.ts
+++ b/frontend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class AppService {
   getHello (): string {
-    return 'Hello CBerg!'
+    return 'Hello CBerg!!'
   }
 }

--- a/frontend/src/app.service.ts
+++ b/frontend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class AppService {
   getHello (): string {
-    return 'Hello CBerg!!'
+    return 'Hello World!'
   }
 }

--- a/frontend/test/app.e2e-spec.ts
+++ b/frontend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello Frontend!'))
+    .expect('Hello CBerg!'))
 })

--- a/frontend/test/app.e2e-spec.ts
+++ b/frontend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello CBerg!!'))
+    .expect('Hello World!'))
 })

--- a/frontend/test/app.e2e-spec.ts
+++ b/frontend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello CBerg!'))
+    .expect('Hello CBerg!!'))
 })


### PR DESCRIPTION
Refactored all usages of nr-quickstart-typescript -> onroutebc

# Description
nr-quickstart-typescript should auto resolve to referencing project name, except in documentation.  For now blindly refactor but work on fixing template. 

Fixes # (issue)
Project is not call nr-quickstart-typescript

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Merge request for pipeline triggering  
- [ ] Accept PR and test pipeline actions


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] Any dependent changes have already been accepted and merged


## Further comments
No further comments.  Iterations necessary for testing. 


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://onroutebc-15-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://onroutebc-15-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)