### PR TITLE
Fix github environment deploy status issue and replace secret search in pr-open workflow

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -68,6 +68,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
+      fail-fast: true
       matrix:
         name: [init, backend/vehicles, frontend]
         include:
@@ -106,6 +107,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
+      fail-fast: true
       matrix:
         name: [init, backend/vehicles, frontend]
         include:

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -67,8 +67,9 @@ jobs:
     environment: test
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
       matrix:
-        name: [backend/vehicles, frontend, init]
+        name: [init, backend/vehicles, frontend]
         include:
           - name: backend/vehicles
             file: backend/vehicles/openshift.deploy.yml
@@ -104,8 +105,9 @@ jobs:
     environment: prod
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
       matrix:
-        name: [backend/vehicles, frontend, init]
+        name: [init, backend/vehicles, frontend]
         include:
           - name: backend/vehicles
             file: backend/vehicles/openshift.deploy.yml

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -33,16 +33,6 @@ jobs:
             Once merged, code will be promoted and handed off to following workflow run.
             [Main Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge-main.yml)
 
-  secret-search:
-    name: Secret Search
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: secret-search
-        uses: Hacks4Snacks/secret-search@v1.1
-        with:
-          exclude-file: docker-compose.yml
-
   builds:
     name: Builds
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -72,8 +72,9 @@ jobs:
       - builds
     runs-on: ubuntu-22.04
     strategy:
+      max-parallel: 1
       matrix:
-        name: [backend/vehicles, init, frontend]
+        name: [init, backend/vehicles, frontend]
         include:
           - name: backend/vehicles
             file: backend/vehicles/openshift.deploy.yml

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -61,8 +61,10 @@ jobs:
     needs:
       - builds
     runs-on: ubuntu-22.04
+    environment: dev
     strategy:
       max-parallel: 1
+      fail-fast: true
       matrix:
         name: [init, backend/vehicles, frontend]
         include:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

GitHub Environment:

There is an open issue in GitHub where the GitHub Environments status label shows a false "inactive" label when the environment has been successfully deployed and should be active. This bug seems to happen when using a matrix deployment workflow. See [here](https://github.com/actions/runner/issues/1001) and [here ](https://github.com/actions/runner/issues/2120)

My solution is to run the deployments in order so that the latest deployment status will be shown on the main page of the repository by setting the "max-parallel" option to 1.


GitHub Secrets:

GitHub has released a built-in secret scanning feature which will replace the secret search code in the pr-open workflow.
It has been enabled in our repo using the following steps:
Settings -> Code Security and Analysis -> Secret Scanning -> Enable

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend - Vehicles](https://onroutebc-135-backend-vehicles.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://onroutebc-135-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)