### PR TITLE
Initial data schema for TROS permit applications

### DIFF
--- a/database/mssql/scripts/utility/add-audit-columns.sql
+++ b/database/mssql/scripts/utility/add-audit-columns.sql
@@ -1,5 +1,6 @@
 -- Search and replace TABLENAME with the name of the table you want
--- audit columns added to.
+-- audit columns added to, and search and replace [dbo] with the name of the
+-- schema the table is from.
 
 USE ORBC_DEV
 GO
@@ -10,16 +11,8 @@ GO
 SET QUOTED_IDENTIFIER ON
 GO
 
-ALTER TABLE TABLENAME ADD
+ALTER TABLE [dbo].[TABLENAME] ADD
 	[CONCURRENCY_CONTROL_NUMBER] [int] NULL,
-	[APP_CREATE_USERID] [varchar](30) NULL,
-	[APP_CREATE_TIMESTAMP] [datetime2](7) NULL,
-	[APP_CREATE_USER_GUID] [uniqueidentifier] NULL,
-	[APP_CREATE_USER_DIRECTORY] [varchar](30) NULL,
-	[APP_LAST_UPDATE_USERID] [varchar](30) NULL,
-	[APP_LAST_UPDATE_TIMESTAMP] [datetime2](7) NULL,
-	[APP_LAST_UPDATE_USER_GUID] [uniqueidentifier] NULL,
-	[APP_LAST_UPDATE_USER_DIRECTORY] [varchar](30) NULL,
 	[DB_CREATE_USERID] [varchar](63) NOT NULL,
 	[DB_CREATE_TIMESTAMP] [datetime2](7) NOT NULL,
 	[DB_LAST_UPDATE_USERID] [varchar](63) NOT NULL,
@@ -38,30 +31,6 @@ ALTER TABLE [dbo].[TABLENAME] ADD  CONSTRAINT [DF_TABLENAME_DB_LAST_UPDATE_TIMES
 GO
 
 EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Application code is responsible for retrieving the row and then incrementing the value of the CONCURRENCY_CONTROL_NUMBER column by one prior to issuing an update. If this is done then the update will succeed, provided that the row was not updated by any other transactions in the period between the read and the update operations.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'CONCURRENCY_CONTROL_NUMBER'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user account name of the application user who performed the action that created the record (e.g. ''JSMITH''). This value is not preceded by the directory name.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_CREATE_USERID'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time of the application action that created the record.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_CREATE_TIMESTAMP'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The Globally Unique Identifier of the application user who performed the action that created the record.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_CREATE_USER_GUID'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The directory in which APP_CREATE_USERID is defined.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_CREATE_USER_DIRECTORY'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user account name of the application user who performed the action that created or last updated the record (e.g. ''JSMITH''). This value is not preceded by the directory name.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_LAST_UPDATE_USERID'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time of the application action that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_LAST_UPDATE_TIMESTAMP'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The Globally Unique Identifier of the application user who performed the action that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_LAST_UPDATE_USER_GUID'
-GO
-
-EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The directory in which APP_LAST_UPDATE_USERID is defined.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'APP_LAST_UPDATE_USER_DIRECTORY'
 GO
 
 EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'dbo', @level1type=N'TABLE',@level1Name=N'TABLENAME', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_USERID'

--- a/database/mssql/scripts/versions/revert/v_4_ddl_revert.sql
+++ b/database/mssql/scripts/versions/revert/v_4_ddl_revert.sql
@@ -1,0 +1,20 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+SET NOCOUNT ON
+GO
+BEGIN TRANSACTION
+
+DROP TABLE [permit].[ORBC_PERMIT_METADATA]
+DROP TABLE [permit].[ORBC_PERMIT]
+DROP TABLE [permit].[ORBC_VT_PERMIT_TYPE]
+DROP TABLE [permit].[ORBC_VT_PERMIT_STATUS]
+DROP SCHEMA [permit]
+
+DECLARE @VersionDescription VARCHAR(255)
+SET @VersionDescription = 'Reverting initial creation of entities for applying for and issuing permits'
+
+INSERT [dbo].[ORBC_SYS_VERSION] ([VERSION_ID], [DESCRIPTION], [DDL_FILE_SHA1], [RELEASE_DATE]) VALUES (3, @VersionDescription, '$(FILE_HASH)', getdate())
+
+COMMIT

--- a/database/mssql/scripts/versions/v_4_ddl.sql
+++ b/database/mssql/scripts/versions/v_4_ddl.sql
@@ -1,0 +1,254 @@
+CREATE SCHEMA [permit]
+GO
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+SET NOCOUNT ON
+GO
+BEGIN TRANSACTION
+
+CREATE TABLE [permit].[ORBC_PERMIT](
+	[PERMIT_ID] [bigint] IDENTITY(1,1) NOT NULL,
+	[PERMIT_DATA] [nvarchar](4000) NULL,
+	[PERMIT_NUMBER]  AS (json_value([PERMIT_DATA],'$.permitNumber')),
+	[START_DATE]  AS (json_value([PERMIT_DATA],'$.startDate')),
+	[CONCURRENCY_CONTROL_NUMBER] [int] NULL,
+	[DB_CREATE_USERID] [varchar](63) NOT NULL,
+	[DB_CREATE_TIMESTAMP] [datetime2](7) NOT NULL,
+	[DB_LAST_UPDATE_USERID] [varchar](63) NOT NULL,
+	[DB_LAST_UPDATE_TIMESTAMP] [datetime2](7) NOT NULL,
+ CONSTRAINT [PK_ORBC_PERMIT] PRIMARY KEY CLUSTERED 
+(
+	[PERMIT_ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [permit].[ORBC_PERMIT_METADATA](
+	[ID] [bigint] IDENTITY(1,1) NOT NULL,
+	[PERMIT_ID] [bigint] NOT NULL,
+	[STATUS_ID] [varchar](20) NOT NULL,
+	[COMPANY_ID] [int] NOT NULL,
+	[PERMIT_TYPE_ID] [varchar](10) NOT NULL,
+	[REVISION] [int] NOT NULL,
+	[CONCURRENCY_CONTROL_NUMBER] [int] NULL,
+	[DB_CREATE_USERID] [varchar](63) NOT NULL,
+	[DB_CREATE_TIMESTAMP] [datetime2](7) NOT NULL,
+	[DB_LAST_UPDATE_USERID] [varchar](63) NOT NULL,
+	[DB_LAST_UPDATE_TIMESTAMP] [datetime2](7) NOT NULL,
+ CONSTRAINT [PK_ORBC_PERMIT_METADATA] PRIMARY KEY CLUSTERED 
+(
+	[ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [permit].[ORBC_VT_PERMIT_STATUS](
+	[PERMIT_STATUS_ID] [varchar](20) NOT NULL,
+	[NAME] [nvarchar](50) NULL,
+	[DESCRIPTION] [nvarchar](250) NULL,
+	[CONCURRENCY_CONTROL_NUMBER] [int] NULL,
+	[DB_CREATE_USERID] [varchar](63) NOT NULL,
+	[DB_CREATE_TIMESTAMP] [datetime2](7) NOT NULL,
+	[DB_LAST_UPDATE_USERID] [varchar](63) NOT NULL,
+	[DB_LAST_UPDATE_TIMESTAMP] [datetime2](7) NOT NULL,
+ CONSTRAINT [PK_ORBC_VT_PERMIT_STATUS] PRIMARY KEY CLUSTERED 
+(
+	[PERMIT_STATUS_ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [permit].[ORBC_VT_PERMIT_TYPE](
+	[PERMIT_TYPE_ID] [varchar](10) NOT NULL,
+	[NAME] [nvarchar](50) NULL,
+	[DESCRIPTION] [nvarchar](250) NULL,
+	[CONCURRENCY_CONTROL_NUMBER] [int] NULL,
+	[DB_CREATE_USERID] [varchar](63) NOT NULL,
+	[DB_CREATE_TIMESTAMP] [datetime2](7) NOT NULL,
+	[DB_LAST_UPDATE_USERID] [varchar](63) NOT NULL,
+	[DB_LAST_UPDATE_TIMESTAMP] [datetime2](7) NOT NULL,
+ CONSTRAINT [PK_ORBC_VT_PERMIT_TYPE] PRIMARY KEY CLUSTERED 
+(
+	[PERMIT_TYPE_ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [permit].[ORBC_PERMIT] ADD  CONSTRAINT [DF_ORBC_PERMIT_DB_CREATE_USERID]  DEFAULT (user_name()) FOR [DB_CREATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT] ADD  CONSTRAINT [DF_ORBC_PERMIT_DB_CREATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_CREATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT] ADD  CONSTRAINT [DF_ORBC_PERMIT_DB_LAST_UPDATE_USERID]  DEFAULT (user_name()) FOR [DB_LAST_UPDATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT] ADD  CONSTRAINT [DF_ORBC_PERMIT_DB_LAST_UPDATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_LAST_UPDATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] ADD  CONSTRAINT [DF_ORBC_PERMIT_METADATA_STATUS_ID]  DEFAULT ('IN_PROGRESS') FOR [STATUS_ID]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] ADD  CONSTRAINT [DF_ORBC_PERMIT_METADATA_REVISION]  DEFAULT ((0)) FOR [REVISION]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] ADD  CONSTRAINT [DF_ORBC_PERMIT_METADATA_DB_CREATE_USERID]  DEFAULT (user_name()) FOR [DB_CREATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] ADD  CONSTRAINT [DF_ORBC_PERMIT_METADATA_DB_CREATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_CREATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] ADD  CONSTRAINT [DF_ORBC_PERMIT_METADATA_DB_LAST_UPDATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_LAST_UPDATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_STATUS] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_STATUS_DB_CREATE_USERID]  DEFAULT (user_name()) FOR [DB_CREATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_STATUS] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_STATUS_DB_CREATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_CREATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_STATUS] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_STATUS_DB_LAST_UPDATE_USERID]  DEFAULT (user_name()) FOR [DB_LAST_UPDATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_STATUS] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_STATUS_DB_LAST_UPDATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_LAST_UPDATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_TYPE] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_TYPE_DB_CREATE_USERID]  DEFAULT (user_name()) FOR [DB_CREATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_TYPE] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_TYPE_DB_CREATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_CREATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_TYPE] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_TYPE_DB_LAST_UPDATE_USERID]  DEFAULT (user_name()) FOR [DB_LAST_UPDATE_USERID]
+GO
+ALTER TABLE [permit].[ORBC_VT_PERMIT_TYPE] ADD  CONSTRAINT [DF_ORBC_VT_PERMIT_TYPE_DB_LAST_UPDATE_TIMESTAMP]  DEFAULT (getdate()) FOR [DB_LAST_UPDATE_TIMESTAMP]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA]  WITH CHECK ADD  CONSTRAINT [FK_ORBC_PERMIT_METADATA_COMPANY] FOREIGN KEY([COMPANY_ID])
+REFERENCES [dbo].[ORBC_COMPANY] ([COMPANY_ID])
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] CHECK CONSTRAINT [FK_ORBC_PERMIT_METADATA_COMPANY]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA]  WITH CHECK ADD  CONSTRAINT [FK_ORBC_PERMIT_METADATA_PERMIT] FOREIGN KEY([PERMIT_ID])
+REFERENCES [permit].[ORBC_PERMIT] ([PERMIT_ID])
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] CHECK CONSTRAINT [FK_ORBC_PERMIT_METADATA_PERMIT]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA]  WITH CHECK ADD  CONSTRAINT [FK_ORBC_PERMIT_METADATA_PERMIT_STATUS] FOREIGN KEY([STATUS_ID])
+REFERENCES [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID])
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] CHECK CONSTRAINT [FK_ORBC_PERMIT_METADATA_PERMIT_STATUS]
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA]  WITH CHECK ADD  CONSTRAINT [FK_ORBC_PERMIT_METADATA_PERMIT_TYPE] FOREIGN KEY([PERMIT_TYPE_ID])
+REFERENCES [permit].[ORBC_VT_PERMIT_TYPE] ([PERMIT_TYPE_ID])
+GO
+ALTER TABLE [permit].[ORBC_PERMIT_METADATA] CHECK CONSTRAINT [FK_ORBC_PERMIT_METADATA_PERMIT_TYPE]
+GO
+
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'APPROVED', N'Approved', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:30:04.8033333' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:30:04.8033333' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'AUTO_APPROVED', N'Auto Approved', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:30:32.2466667' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:30:32.2466667' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'CANCELLED', N'Cancelled', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:30:40.2200000' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:30:40.2200000' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'IN_PROGRESS', N'In Progress', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:30:50.3466667' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:30:50.3466667' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'ISSUED', N'Issued', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:30:58.0100000' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:30:58.0100000' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'REJECTED', N'Rejected', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:31:05.4300000' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:31:05.4300000' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'REVOKED', N'Revoked', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:31:18.6266667' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:31:18.6266667' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'SUPERSEDED', N'Superseded', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:31:25.5333333' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:31:25.5333333' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'UNDER_REVIEW', N'Under Review', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:31:39.3700000' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:31:39.3700000' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'VOIDED', N'Voided', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:31:42.8900000' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:31:42.8900000' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'WAITING_APPROVAL', N'Waiting Approval', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:32:00.8433333' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:32:00.8433333' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_STATUS] ([PERMIT_STATUS_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'WAITING_PAYMENT', N'Waiting Payment', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:32:09.2566667' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:32:09.2566667' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_TYPE] ([PERMIT_TYPE_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'STOS', N'Single Trip Oversize', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:28:06.8366667' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:28:06.8366667' AS DateTime2))
+GO
+INSERT [permit].[ORBC_VT_PERMIT_TYPE] ([PERMIT_TYPE_ID], [NAME], [DESCRIPTION], [CONCURRENCY_CONTROL_NUMBER], [DB_CREATE_USERID], [DB_CREATE_TIMESTAMP], [DB_LAST_UPDATE_USERID], [DB_LAST_UPDATE_TIMESTAMP]) VALUES (N'TROS', N'Term Oversize', NULL, NULL, N'dbo', CAST(N'2023-03-31T21:28:06.8466667' AS DateTime2), N'dbo', CAST(N'2023-03-31T21:28:06.8466667' AS DateTime2))
+GO
+
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Unique ID of the permit record and revision (each revision is its own ID)' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'PERMIT_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'JSON structured data representing the permit details' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'PERMIT_DATA'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Calculated column for the permit number, pulled from the JSON PERMIT_DATA' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'PERMIT_NUMBER'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Calculated column for the permit start date, pulled from the JSON PERMIT_DATA' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'START_DATE'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Application code is responsible for retrieving the row and then incrementing the value of the CONCURRENCY_CONTROL_NUMBER column by one prior to issuing an update. If this is done then the update will succeed, provided that the row was not updated by any other transactions in the period between the read and the update operations.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'CONCURRENCY_CONTROL_NUMBER'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'DB_CREATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'DB_CREATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created or last updated.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Surrogate primary key ID for the permit metadata record' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Foreign key to the ORBC_PERMIT table' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'PERMIT_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Foreign key to the ORBC_VT_PERMIT_STATUS table, represents the current status of the permit' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'STATUS_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Foreign key to the ORBC_COMPANY table, represents the company requesting the permit' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'COMPANY_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Foreign key to the ORBC_VT_PERMIT_TYPE table, represents the type of permit' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'PERMIT_TYPE_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Revision of the permit, begins with zero and increments by 1 for each subsequent revision' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'REVISION'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Application code is responsible for retrieving the row and then incrementing the value of the CONCURRENCY_CONTROL_NUMBER column by one prior to issuing an update. If this is done then the update will succeed, provided that the row was not updated by any other transactions in the period between the read and the update operations.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'CONCURRENCY_CONTROL_NUMBER'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'DB_CREATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'DB_CREATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created or last updated.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_PERMIT_METADATA', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Unique id of the permit status' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'PERMIT_STATUS_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Friendly name of the permit status' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'NAME'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Long description of the permit status' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'DESCRIPTION'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Application code is responsible for retrieving the row and then incrementing the value of the CONCURRENCY_CONTROL_NUMBER column by one prior to issuing an update. If this is done then the update will succeed, provided that the row was not updated by any other transactions in the period between the read and the update operations.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'CONCURRENCY_CONTROL_NUMBER'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'DB_CREATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'DB_CREATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created or last updated.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_STATUS', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Unique ID of the permit type' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'PERMIT_TYPE_ID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Friendly name for the permit type' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'NAME'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Long description of the permit type' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'DESCRIPTION'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'Application code is responsible for retrieving the row and then incrementing the value of the CONCURRENCY_CONTROL_NUMBER column by one prior to issuing an update. If this is done then the update will succeed, provided that the row was not updated by any other transactions in the period between the read and the update operations.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'CONCURRENCY_CONTROL_NUMBER'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'DB_CREATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'DB_CREATE_TIMESTAMP'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The user or proxy account that created or last updated the record.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_USERID'
+GO
+EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'The date and time the record was created or last updated.' , @level0type=N'SCHEMA',@level0name=N'permit', @level1type=N'TABLE',@level1name=N'ORBC_VT_PERMIT_TYPE', @level2type=N'COLUMN',@level2name=N'DB_LAST_UPDATE_TIMESTAMP'
+GO
+
+DECLARE @VersionDescription VARCHAR(255)
+SET @VersionDescription = 'Initial creation of entities for applying for and issuing permits'
+
+INSERT [dbo].[ORBC_SYS_VERSION] ([VERSION_ID], [DESCRIPTION], [DDL_FILE_SHA1], [RELEASE_DATE]) VALUES (4, @VersionDescription, '$(FILE_HASH)', getdate())
+
+COMMIT


### PR DESCRIPTION
# Description

Add database schema objects for the initial Term Oversize permit applications, including a facility to allow storage of raw JSON permit data in the database and having calculated fields in the table dynamically assigned from the JSON contents.

Fixes # ORV2-505 (partial)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Run local docker container, verify in the sql server db container console that no errors occur
- [X] After running local docker container, verify the entities exist as expected using SSMS
- [X] Attempt to insert a permit record with minimal JSON data in the PERMIT_DATA column of {"permitNumber": "testNum", "startDate": "2023-03-31"} and ensure the calculated values appear as expected.

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (TBD)
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have already been accepted and merged

## Further comments

This is an initial cut of the permit data model for TROS specifically and is not set in stone. We'll use this to start and as changes are needed by fe/be we can adjust as necessary.


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend - Vehicles](https://onroutebc-278-backend-vehicles.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://onroutebc-278-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)