### PR TITLE
Fix: Added unit number field to tros application payload on post request

### DIFF
--- a/frontend/src/features/permits/pages/TermOversize/form/VehicleDetails/customFields/SelectVehicleDropdown.tsx
+++ b/frontend/src/features/permits/pages/TermOversize/form/VehicleDetails/customFields/SelectVehicleDropdown.tsx
@@ -79,6 +79,7 @@ export const SelectVehicleDropdown = ({
   const clearAllFields = () => {
     setSelectedVehicle("");
     setValue("application.vehicleDetails", {
+      unitNumber: "",
       vin: "",
       plate: "",
       make: "",
@@ -101,6 +102,7 @@ export const SelectVehicleDropdown = ({
 
     setSelectedVehicle(selectedVehicle.plate);
     setValue("application.vehicleDetails", {
+      unitNumber: vehicle.unitNumber,
       vin: vehicle.vin,
       plate: vehicle.plate,
       make: vehicle.make,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

If the user is updating an existing vehicle from the TROS application page then pass the existing unit number in the application POST request.

If the user is creating a new vehicle from the TROS application page, then there is no field to enter a unit number, so the unit number will be null.

Currently, the frontend checks for an existing vehicle by VIN.

![image](https://github.com/bcgov/onroutebc/assets/105307931/f7246c92-c7c5-4f26-9cdd-f5a3f3b50ab1)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested locally by submitting a new application

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
