### PR TITLE
Feat: Replace Dependabot with Renovate for dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,24 @@
-# Dependency updates for GitHub Actions and npm
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
+# # Dependency updates for GitHub Actions and npm
+# # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# version: 2
+# updates:
+#   - package-ecosystem: github-actions
+#     directory: /
+#     schedule:
+#       interval: weekly
 
-  - package-ecosystem: npm
-    directory: /backend/vehicles
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "Backend"
-      include: "scope"
+#   - package-ecosystem: npm
+#     directory: /backend/vehicles
+#     schedule:
+#       interval: weekly
+#     commit-message:
+#       prefix: "Backend"
+#       include: "scope"
 
-  - package-ecosystem: npm
-    directory: /frontend
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "Frontend"
-      include: "scope"
+#   - package-ecosystem: npm
+#     directory: /frontend
+#     schedule:
+#       interval: weekly
+#     commit-message:
+#       prefix: "Frontend"
+#       include: "scope"


### PR DESCRIPTION
We've switched to Mend Renovate for dependency PRs.  This PR disables Dependabot PRs, cutting down on duplicate patches/updates.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend - Vehicles](https://onroutebc-456-backend-vehicles.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://onroutebc-456-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)