### PR TITLE
ORV2-924 Empty trailer width must be numeric

### DIFF
--- a/frontend/src/features/manageVehicles/components/form/TrailerForm.tsx
+++ b/frontend/src/features/manageVehicles/components/form/TrailerForm.tsx
@@ -13,9 +13,16 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useContext } from "react";
 import { SnackBarContext } from "../../../../App";
-import { getDefaultRequiredVal, getDefaultNullableVal } from "../../../../common/helpers/util";
-import { 
-  invalidNumber, invalidPlateLength, invalidVINLength, invalidYearMin, requiredMessage 
+import {
+  getDefaultRequiredVal,
+  getDefaultNullableVal,
+} from "../../../../common/helpers/util";
+import {
+  invalidNumber,
+  invalidPlateLength,
+  invalidVINLength,
+  invalidYearMin,
+  requiredMessage,
 } from "../../../../common/helpers/validationMessages";
 
 /**
@@ -82,7 +89,7 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
         trailer: {
           ...trailerToBeUpdated,
           // need to explicitly convert form values to number here (since we can't use valueAsNumber prop)
-          year: !isNaN(Number(data.year)) ? Number(data.year) : data.year
+          year: !isNaN(Number(data.year)) ? Number(data.year) : data.year,
         },
       });
       if (result.ok) {
@@ -99,7 +106,7 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
       const result = await addTrailerMutation.mutateAsync({
         ...trailerToBeAdded,
         // need to explicitly convert form values to number here (since we can't use valueAsNumber prop)
-        year: !isNaN(Number(data.year)) ? Number(data.year) : data.year
+        year: !isNaN(Number(data.year)) ? Number(data.year) : data.year,
       });
       if (result.ok) {
         snackBar.setSnackBar({
@@ -146,9 +153,9 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
             options={{
               name: "make",
               rules: {
-                required: { 
+                required: {
                   value: true,
-                  message: requiredMessage()
+                  message: requiredMessage(),
                 },
                 maxLength: 20,
               },
@@ -163,13 +170,14 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
             options={{
               name: "year",
               rules: {
-                required: { 
+                required: {
                   value: true,
-                  message: requiredMessage()
+                  message: requiredMessage(),
                 },
                 validate: {
                   isNumber: (v) => !isNaN(v) || invalidNumber(),
-                  lessThan1950: v => parseInt(v) > 1950 || invalidYearMin(1950),
+                  lessThan1950: (v) =>
+                    parseInt(v) > 1950 || invalidYearMin(1950),
                 },
                 maxLength: 4,
               },
@@ -185,13 +193,13 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
             options={{
               name: "vin",
               rules: {
-                required: { 
+                required: {
                   value: true,
-                  message: requiredMessage()
+                  message: requiredMessage(),
                 },
-                minLength: { 
+                minLength: {
                   value: 6,
-                  message: invalidVINLength(6)
+                  message: invalidVINLength(6),
                 },
                 maxLength: 6,
               },
@@ -207,13 +215,13 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
             options={{
               name: "plate",
               rules: {
-                required: { 
-                  value: true, 
-                  message: requiredMessage()
+                required: {
+                  value: true,
+                  message: requiredMessage(),
                 },
-                maxLength: { 
+                maxLength: {
                   value: 10,
-                  message: invalidPlateLength(10)
+                  message: invalidPlateLength(10),
                 },
               },
               label: "Plate",
@@ -247,7 +255,13 @@ export const TrailerForm = ({ trailer }: TrailerFormProps) => {
             feature={FEATURE}
             options={{
               name: "emptyTrailerWidth",
-              rules: { required: false, maxLength: 10 },
+              rules: {
+                required: false,
+                maxLength: 10,
+                validate: {
+                  isNumber: (v) => !isNaN(v) || invalidNumber(),
+                },
+              },
               label: "Empty Trailer Width (m)",
               width: formFieldStyle.width,
             }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Added validation to ensure that the Empty Trailer Width is a number


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend - Vehicles](https://onroutebc-519-backend-vehicles.apps.silver.devops.gov.bc.ca/) available
[Backend - DMS](https://onroutebc-519-backend-dms.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://onroutebc-519-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)