### PR TITLE
fix: remove duplicate runs-on in pentests.yml

### DIFF
--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -3,6 +3,7 @@ name: Penetration Tests
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -10,7 +10,6 @@ concurrency:
 
 jobs:
   zap_scan:
-    runs-on: ubuntu-latest
     name: Penetration Tests
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca

--- a/.github/workflows/pentests.yml
+++ b/.github/workflows/pentests.yml
@@ -3,7 +3,6 @@ name: Penetration Tests
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,7 @@
 name: PR
 
 on:
-  # pull_request:
-  workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,7 +1,8 @@
 name: PR
 
 on:
-  pull_request:
+  # pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Duplicate field causing penetration test workflow to fail.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend - Vehicles](https://onroutebc-671-backend-vehicles.apps.silver.devops.gov.bc.ca/) available
[Backend - DOPS](https://onroutebc-671-backend-dops.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://onroutebc-671-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge-main.yml)