### PR TITLE
ci: sonarcloud setup

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -108,4 +108,4 @@ jobs:
             -Dsonar.tests.inclusions=**/*spec.ts
             -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
           sonar_token: ${{ secrets[matrix.token] }}
-          triggers: ${{ matrix.triggers }}
+          # triggers: ${{ matrix.triggers }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -81,15 +81,15 @@ jobs:
         dir: [backend/vehicles, backend/dops, frontend]
         include:
           - dir: backend/dops
-            sonar_projectKey: bcgov_onroutebc_dops
-            token: SONAR_TOKEN_BACKEND
+            sonar_projectKey: onroutebc_dops
+            token: SONAR_TOKEN_DOPS
             triggers: ('backend/dops')
           - dir: backend/vehicles
-            sonar_projectKey: bcgov_onroutebc_vehicles
-            token: SONAR_TOKEN_BACKEND
+            sonar_projectKey: onroutebc_vehicles
+            token: SONAR_TOKEN_VEHICLES
             triggers: ('backend/dops')
           - dir: frontend
-            sonar_projectKey: bcgov_onroutebc_frontend
+            sonar_projectKey: onroutebc_frontend
             token: SONAR_TOKEN_FRONTEND
             triggers: ('frontend/')
     steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -81,11 +81,11 @@ jobs:
         dir: [backend/vehicles, backend/dops, frontend]
         include:
           - dir: backend/dops
-            sonar_projectKey: bcgov_onroutebc_backend
+            sonar_projectKey: bcgov_onroutebc_dops
             token: SONAR_TOKEN_BACKEND
             triggers: ('backend/dops')
           - dir: backend/vehicles
-            sonar_projectKey: bcgov_onroutebc_backend
+            sonar_projectKey: bcgov_onroutebc_vehicles
             token: SONAR_TOKEN_BACKEND
             triggers: ('backend/dops')
           - dir: frontend
@@ -99,7 +99,7 @@ jobs:
             npm ci
             npm run test:cov
           dir: ${{ matrix.dir }}
-          node_version: "20"
+          node_version: "18"
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
             -Dsonar.organization=bcgov-sonarcloud

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -108,4 +108,4 @@ jobs:
             -Dsonar.tests.inclusions=**/*spec.ts
             -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
           sonar_token: ${{ secrets[matrix.token] }}
-          # triggers: ${{ matrix.triggers }}
+          triggers: ${{ matrix.triggers }}


### PR DESCRIPTION
Get SonarCloud using a monorepo setup, which can handle the individual services in this repo.

[Request/issue](https://github.com/BCDevOps/devops-requests/issues/1578)

SonarCloud projects:
* https://sonarcloud.io/project/information?id=onroutebc_dops
* https://sonarcloud.io/project/information?id=onroutebc_frontend
* https://sonarcloud.io/project/information?id=onroutebc_vehicles

Node tests have been dialed down to `18` to match the Dockerfiles.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-771-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-771-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-771-dops.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)