### PR TITLE
ci: change coverage dirs for dops and vehichles

### DIFF
--- a/dops/package.json
+++ b/dops/package.json
@@ -135,7 +135,7 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "./coverage",
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/",

--- a/vehicles/package.json
+++ b/vehicles/package.json
@@ -134,7 +134,7 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "./coverage",
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/",


### PR DESCRIPTION
SonarCloud is missing coverage reports, since they're grouped under the repo root instead of individual projects.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-808-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-808-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-808-dops.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)