### PR TITLE
ci: PR close/open interrupt, but not merge_groups

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -5,8 +5,8 @@ on:
   merge_group:
 
 concurrency:
-  #  PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
+  # Cancel in progress for PR open and close, but not merge_group
+  group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.base_sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-847-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-847-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-847-dops.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)