### PR TITLE
ci: only let MERGED PRs promote images

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -34,6 +34,7 @@ jobs:
  # Add tags to PR image
   retags:
     name: Promote Images
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-22.04
     permissions:
       packages: write


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1020-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1020-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1020-dops.apps.silver.devops.gov.bc.ca/api)
- [TPS-Migration](https://onroutebc-1020-tps-migration.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)