### PR TITLE
fix: Explicitly call pending IDIR user sample data script in docker load script

### DIFF
--- a/database/mssql/configure-db.sh
+++ b/database/mssql/configure-db.sh
@@ -49,5 +49,6 @@ migrate_db_current ${MSSQL_SA_USER} "${MSSQL_SA_PASSWORD}" "${MSSQL_HOST}" ${MSS
 
 # Load sample data if configured
 if [[ ${MSSQL_LOAD_SAMPLE_DATA} -eq 1 ]]; then
-  /usr/config/utility/refresh-sample-data.sh -u ${MSSQL_SA_USER} -p "${MSSQL_SA_PASSWORD}" -s ${MSSQL_HOST} -d ${MSSQL_DB} 
+  /usr/config/utility/refresh-sample-data.sh -u ${MSSQL_SA_USER} -p '"${MSSQL_SA_PASSWORD}"' -s ${MSSQL_HOST} -d ${MSSQL_DB} 
+  /usr/config/utility/refresh-sample-idir-users.sh -u ${MSSQL_SA_USER} -p '"${MSSQL_SA_PASSWORD}"' -s ${MSSQL_HOST} -d ${MSSQL_DB} 
 fi


### PR DESCRIPTION
# Description

Previous change to better handle passwords rearranged the idir user script; this needed to be explicitly called now from the docker compose script.

Fixes # ORV2-1835

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Ran docker compose up and verified using console and SSMS that the idir users are now being inserted

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1046-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1046-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1046-dops.apps.silver.devops.gov.bc.ca/api)
- [TPS-Migration](https://onroutebc-1046-tps-migration.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)