### PR TITLE
fix(ci): workflow cleanup

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   merge_group:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   schedule:
     - cron: "0 11 * * 0" # 3 AM PST = 12 PM UDT, runs sundays
   workflow_dispatch:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -35,29 +35,6 @@ jobs:
         with:
           category: "/language:javascript"
 
-  # https://github.com/marketplace/actions/aqua-security-trivy
-  trivy:
-    name: Trivy Security Scan
-    if: ${{ ! github.event.pull_request.draft }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 1
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.17.0
-        with:
-          format: "sarif"
-          output: "trivy-results.sarif"
-          ignore-unfixed: true
-          scan-type: "fs"
-          scanners: "vuln,secret,config"
-          severity: "CRITICAL,HIGH"
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: "trivy-results.sarif"
-
   tests:
     name: Tests
     if: ${{ ! github.event.pull_request.draft }}
@@ -115,11 +92,27 @@ jobs:
           sonar_token: ${{ secrets[matrix.token] }}
           triggers: ${{ matrix.triggers }}
 
-  results:
-    name: Results
-    needs: [codeql, trivy, tests]
-    if: always() && (! failure())
+  # https://github.com/marketplace/actions/aqua-security-trivy
+  trivy:
+    name: Trivy Security Scan
+    if: ${{ ! github.event.pull_request.draft }}
+    needs: [codeql, tests]
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
-      - run: echo "Success!"
+      - uses: actions/checkout@v4
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.17.0
+        with:
+          format: "sarif"
+          output: "trivy-results.sarif"
+          ignore-unfixed: true
+          scan-type: "fs"
+          scanners: "vuln,secret,config"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -2,60 +2,16 @@ name: PR
 
 on:
   pull_request:
-  merge_group:
 
 concurrency:
-  # Cancel in progress for PR open and close, but not merge_group
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.base_sha }}
+  # Cancel in progress for PR open and close
+  group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
-  pr-description-add:
-    name: PR Description Add
-    if: github.event_name == 'pull_request'
-    env:
-      DOMAIN: apps.silver.devops.gov.bc.ca
-      PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write
-    timeout-minutes: 1
-    steps:
-      - uses: bcgov-nr/action-pr-description-add@v1.1.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          add_markdown: |
-            ---
-
-            Thanks for the PR!
-
-            Deployments, as required, will be available below:
-            - [Frontend](https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }})
-            - [Vehicles](https://${{ env.PREFIX }}-vehicles.${{ env.DOMAIN }}/api)
-            - [Dops](https://${{ env.PREFIX }}-dops.${{ env.DOMAIN }}/api)
-            - [TPS-Migration](https://${{ env.PREFIX }}-tps-migration.${{ env.DOMAIN }}/api)
-
-            Please create PRs in draft mode.  Mark as ready to enable:
-            - [Analysis Workflow](https://github.com/${{ github.repository }}/actions/workflows/analysis.yml)
-
-            After merge, new images are promoted to:
-            - [Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge.yml)
-
-  # Get PR number for merge queues, otherwise jusr use github.event.nuber
-  vars:
-    name: Set Variables
-    outputs:
-      pr: ${{ steps.pr.outputs.pr }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: PR Number
-        id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1
-
   # https://github.com/bcgov-nr/action-builder-ghcr
   builds:
     name: Builds
-    needs: [vars]
     runs-on: ubuntu-22.04
     permissions:
       packages: write
@@ -68,22 +24,22 @@ jobs:
         with:
           keep_versions: 50
           package: ${{ matrix.package }}
-          tag: ${{ needs.vars.outputs.pr }}
+          tag: ${{ github.event.number }}
           tag_fallback: latest
           triggers: '${{ matrix.package }}/' #omit to build everything
 
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:
     name: Deploys
-    needs: [builds, vars]
+    needs: [builds]
     uses: ./.github/workflows/deploy.yml
     secrets: inherit
     with:
       autoscaling: false
       repository: ${{ github.event.repository.name }}
       environment: dev
-      release: ${{ needs.vars.outputs.pr }}
-      tag: ${{ needs.vars.outputs.pr }}
+      release: ${{ github.event.number }}
+      tag: ${{ github.event.number }}
       triggers: '' #omit=always;
       vault_role: nonprod
       vault_zone: dev


### PR DESCRIPTION
ci fixes:
- duplicate pr-description-add
- merge_group leftovers
- allow analysis to be updated by draft status
- reorder analysis workflow w/o results stub

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1178-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://onroutebc-1178-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1178-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://onroutebc-1178-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)