### PR TITLE
chore(ci): force Helm rollouts

### DIFF
--- a/charts/service/templates/deploymentconfig.yaml
+++ b/charts/service/templates/deploymentconfig.yaml
@@ -23,6 +23,7 @@ spec:
   template:
     metadata:
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
         {{- include "service.podAnnotations" . | nindent 8 }}
         {{- include "service.vaultAnnotations" . | nindent 8 }}
       labels:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -158,6 +158,8 @@ objects:
   - apiVersion: v1
     kind: DeploymentConfig
     metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}


### PR DESCRIPTION
Helm rollouts have had the occasional glitch, missing a deployment.  This PR adds a random number as an annotation field, fooling Helm into a default triggered state.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1263-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1263-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1263-dops.apps.silver.devops.gov.bc.ca/api)
- [TPS-Migration](https://onroutebc-1263-tps-migration.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)