### PR TITLE
ORV2-2215: Fix resend permit and receipt feature

### DIFF
--- a/frontend/src/common/constants/validation_messages.json
+++ b/frontend/src/common/constants/validation_messages.json
@@ -4,6 +4,9 @@
     "messageTemplate": ":fieldName is required",
     "placeholders": [":fieldName"]
   },
+  "selectionRequired": {
+    "defaultMessage": "Select at least one item"
+  },
   "NaN": {
     "defaultMessage": "Must be a number"
   },

--- a/frontend/src/common/helpers/validationMessages.ts
+++ b/frontend/src/common/helpers/validationMessages.ts
@@ -13,6 +13,7 @@ const replacePlaceholders = (
 };
 
 export const requiredMessage = () => validationMessages.required.defaultMessage;
+export const selectionRequired = () => validationMessages.selectionRequired.defaultMessage;
 export const invalidNumber = () => validationMessages.NaN.defaultMessage;
 export const invalidCountryCode = () =>
   validationMessages.country.defaultMessage;

--- a/frontend/src/features/idir/search/components/IDIRPermitSearchRowActions.tsx
+++ b/frontend/src/features/idir/search/components/IDIRPermitSearchRowActions.tsx
@@ -6,9 +6,9 @@ import PermitResendDialog from "./PermitResendDialog";
 import { viewReceiptPdf } from "../../../permits/helpers/permitPDFHelper";
 import * as routes from "../../../../routes/constants";
 import { USER_AUTH_GROUP } from "../../../../common/authentication/types";
-import { Nullable } from "../../../../common/types/common";
 import { useResendPermit } from "../../../permits/hooks/hooks";
 import { SnackBarContext } from "../../../../App";
+import { EmailNotificationType } from "../../../permits/types/EmailNotificationType";
 
 const PERMIT_ACTION_TYPES = {
   RESEND: "resend",
@@ -90,7 +90,6 @@ export const IDIRPermitSearchRowActions = ({
   isPermitInactive,
   permitNumber,
   email,
-  fax,
   userAuthGroup,
   companyId,
 }: {
@@ -110,10 +109,6 @@ export const IDIRPermitSearchRowActions = ({
    * The email address (for use in resend dialog)
    */
   email?: string;
-  /**
-   * The fax number (for use in resend dialog)
-   */
-  fax?: string;
   /**
    * The auth group for the current user (eg. PPCCLERK or EOFFICER)
    */
@@ -145,12 +140,12 @@ export const IDIRPermitSearchRowActions = ({
   const handleResend = async (
     permitId: string,
     email: string,
-    fax?: Nullable<string>,
+    notificationTypes: EmailNotificationType[],
   ) => {
     const response = await resendPermitMutation.mutateAsync({
       permitId,
       email,
-      fax,
+      notificationTypes,
     });
 
     setOpenResendDialog(false);
@@ -173,13 +168,13 @@ export const IDIRPermitSearchRowActions = ({
         options={getOptions(isPermitInactive, userAuthGroup)}
         key={`idir-search-row-${permitNumber}`}
       />
+
       <PermitResendDialog
         shouldOpen={openResendDialog}
         onCancel={() => setOpenResendDialog(false)}
         onResend={handleResend}
         permitId={permitId}
         email={email}
-        fax={fax}
         permitNumber={permitNumber}
       />
     </>

--- a/frontend/src/features/idir/search/components/PermitResendDialog.scss
+++ b/frontend/src/features/idir/search/components/PermitResendDialog.scss
@@ -70,4 +70,35 @@
     margin-bottom: 0;
     margin-top: 1.5rem;
   }
+
+  & &__notification-types {
+    display: block;
+    margin-top: 1.5rem;
+
+    .notification-type {
+      display: flex;
+      align-items: center;
+  
+      &__checkbox {
+        padding: 0;
+
+        &--invalid {
+          color: $bc-red;
+        }
+      }
+  
+      &__label {
+        margin-left: 0.5rem;
+      }
+  
+      &--receipt {
+        margin-top: 1.5rem;
+      }
+    }
+  }
+
+  & &__error-msg {
+    color: $bc-red;
+    margin-top: 0.5rem;
+  }
 }

--- a/frontend/src/features/idir/search/components/PermitResendDialog.tsx
+++ b/frontend/src/features/idir/search/components/PermitResendDialog.tsx
@@ -96,10 +96,8 @@ export default function PermitResendDialog({
 
   const handleResend = (formData: PermitResendFormData) => {
     const { permitId, email, notificationTypes } = formData;
-    const selectedNotificationTypes = [
-      notificationTypes.EMAIL_PERMIT ? EMAIL_NOTIFICATION_TYPES.PERMIT : undefined,
-      notificationTypes.EMAIL_RECEIPT ? EMAIL_NOTIFICATION_TYPES.RECEIPT : undefined,
-    ].filter(type => Boolean(type)) as EmailNotificationType[];
+    const selectedNotificationTypes = Object.keys(notificationTypes)
+      .filter(type => notificationTypes[type as EmailNotificationType]) as EmailNotificationType[];
 
     onResend(permitId, email, selectedNotificationTypes);
   };

--- a/frontend/src/features/permits/apiManager/permitsAPI.ts
+++ b/frontend/src/features/permits/apiManager/permitsAPI.ts
@@ -1,14 +1,16 @@
 import { AxiosResponse } from "axios";
 
+import { PermitHistory } from "../types/PermitHistory";
+import { removeEmptyIdsFromPermitsActionResponse } from "../helpers/mappers";
+import { AmendPermitFormData } from "../pages/Amend/types/AmendPermitFormData";
+import { EmailNotificationType } from "../types/EmailNotificationType";
 import { DATE_FORMATS, toLocal } from "../../../common/helpers/formatDate";
 import {
   IssuePermitsResponse,
   PermitListItem,
   PermitResponseData,
 } from "../types/permit";
-import { PermitHistory } from "../types/PermitHistory";
-import { removeEmptyIdsFromPermitsActionResponse } from "../helpers/mappers";
-import { AmendPermitFormData } from "../pages/Amend/types/AmendPermitFormData";
+
 import {
   Nullable,
   PaginatedResponse,
@@ -557,26 +559,28 @@ export const modifyAmendmentApplication = async ({
 };
 
 /**
- * Resend permit to email (and fax if provided).
+ * Resend permit and/or receipt to email.
  * @param permitId Permit id of the permit to resend
  * @param email Email to resend to
- * @param fax Fax to resend to (if provided)
+ * @param notificationTypes Types of email notifications to send (EMAIL_PERMIT and/or EMAIL_RECEIPT)
  * @returns Response if the resend action was successful
  */
 export const resendPermit = async ({
   permitId,
   email,
-  fax,
+  notificationTypes,
 }: {
   permitId: string;
   email: string;
-  fax?: Nullable<string>;
+  notificationTypes: EmailNotificationType[];
 }) => {
   return await httpPOSTRequest(
     `${PERMITS_API_ROUTES.RESEND(permitId)}`,
     replaceEmptyValuesWithNull({
       to: [email],
-      fax,
+      notificationType: [
+        ...notificationTypes,
+      ],
     }),
   );
 };

--- a/frontend/src/features/permits/types/EmailNotificationType.ts
+++ b/frontend/src/features/permits/types/EmailNotificationType.ts
@@ -1,0 +1,6 @@
+export const EMAIL_NOTIFICATION_TYPES = {
+  PERMIT: "EMAIL_PERMIT",
+  RECEIPT: "EMAIL_RECEIPT",
+} as const;
+
+export type EmailNotificationType = typeof EMAIL_NOTIFICATION_TYPES[keyof typeof EMAIL_NOTIFICATION_TYPES];


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Fixed resend permit and receipt feature based on latest changes on the backend and discussions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Log in as staff user, and go to the permit search page. Select the actions for any permit and click "Resend", and observe that 1) the dialog has changed, and user can now select whether to resend the permit or receipt (or both), and 2) fax input has now been removed. Entering the email and selecting either permit or receipt (or both) will send the corresponding permit/receipt (or both) to the email specified. If neither permit nor receipt checkboxes are selected, clicking "Resend" button should display error message: "Select at least one item". 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1332-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1332-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1332-dops.apps.silver.devops.gov.bc.ca/api)
- [TPS-Migration](https://onroutebc-1332-tps-migration.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)