### PR TITLE
ORV2-2028 - Handle leap year for calculating expiry dates with 1-year duration on FE

### DIFF
--- a/frontend/src/features/permits/components/dashboard/tests/integration/fixtures/getActiveApplication.ts
+++ b/frontend/src/features/permits/components/dashboard/tests/integration/fixtures/getActiveApplication.ts
@@ -4,11 +4,12 @@ import { getDefaultUserDetails } from "./getUserDetails";
 import { getDefaultPowerUnits } from "./getVehicleInfo";
 import { getDefaultCompanyInfo } from "./getCompanyInfo";
 import { TROS_COMMODITIES } from "../../../../../constants/tros";
-import { PERMIT_TYPES } from "../../../../../types/PermitType";
+import { DEFAULT_PERMIT_TYPE, PERMIT_TYPES } from "../../../../../types/PermitType";
 import { getExpiryDate } from "../../../../../helpers/permitState";
 import { VEHICLE_TYPES } from "../../../../../../manageVehicles/types/Vehicle";
 import { PermitStatus } from "../../../../../types/PermitStatus";
 import { getDefaultRequiredVal } from "../../../../../../../common/helpers/util";
+import { minDurationForPermitType } from "../../../../../helpers/dateSelection";
 import {
   DATE_FORMATS,
   dayjsToLocalStr,
@@ -138,7 +139,9 @@ export const resetApplicationSource = () => {
 export const getDefaultApplication = () => {
   const currentDt = getStartOfDate(now());
   const startDate = dayjsToLocalStr(currentDt, DATE_FORMATS.DATEONLY);
-  const expiryDt = getExpiryDate(currentDt, 30);
+  const permitType = DEFAULT_PERMIT_TYPE;
+  const minDuration = minDurationForPermitType(permitType);
+  const expiryDt = getExpiryDate(currentDt, minDuration);
   const expiryDate = dayjsToLocalStr(expiryDt, DATE_FORMATS.DATEONLY);
   const { companyId, userDetails } = getDefaultUserDetails();
   
@@ -180,10 +183,10 @@ export const getDefaultApplication = () => {
   return {
     companyId,
     userGuid: "AB1CD2EFAB34567CD89012E345FA678B",
-    permitType: PERMIT_TYPES.TROS,
+    permitType,
     permitData: {
       startDate,
-      permitDuration: 30,
+      permitDuration: minDuration,
       expiryDate,
       contactDetails,
       vehicleDetails,

--- a/frontend/src/features/permits/constants/constants.ts
+++ b/frontend/src/features/permits/constants/constants.ts
@@ -26,3 +26,19 @@ export const PERMIT_TYPE_CHOOSE_FROM_OPTIONS = [
 ];
 
 export const BASE_DAYS_IN_YEAR = 365;
+export const COMMON_MIN_DURATION = 30;
+
+export const COMMON_DURATION_OPTIONS = [
+  { value: COMMON_MIN_DURATION, label: "30 Days" },
+  { value: 60, label: "60 Days" },
+  { value: 90, label: "90 Days" },
+  { value: 120, label: "120 Days" },
+  { value: 150, label: "150 Days" },
+  { value: 180, label: "180 Days" },
+  { value: 210, label: "210 Days" },
+  { value: 240, label: "240 Days" },
+  { value: 270, label: "270 Days" },
+  { value: 300, label: "300 Days" },
+  { value: 330, label: "330 Days" },
+  { value: BASE_DAYS_IN_YEAR, label: "1 Year" },
+];

--- a/frontend/src/features/permits/constants/constants.ts
+++ b/frontend/src/features/permits/constants/constants.ts
@@ -25,17 +25,4 @@ export const PERMIT_TYPE_CHOOSE_FROM_OPTIONS = [
   { value: PERMIT_TYPES.TROW, label: getPermitTypeName(PERMIT_TYPES.TROW) },
 ];
 
-export const PERMIT_DURATION_OPTIONS = [
-  { value: 30, label: "30 Days" },
-  { value: 60, label: "60 Days" },
-  { value: 90, label: "90 Days" },
-  { value: 120, label: "120 Days" },
-  { value: 150, label: "150 Days" },
-  { value: 180, label: "180 Days" },
-  { value: 210, label: "210 Days" },
-  { value: 240, label: "240 Days" },
-  { value: 270, label: "270 Days" },
-  { value: 300, label: "300 Days" },
-  { value: 330, label: "330 Days" },
-  { value: 365, label: "1 Year" },
-];
+export const BASE_DAYS_IN_YEAR = 365;

--- a/frontend/src/features/permits/constants/tros.ts
+++ b/frontend/src/features/permits/constants/tros.ts
@@ -1,5 +1,6 @@
 import { tros } from "./tros.json";
 import { PermitCommodity } from "../types/PermitCommodity";
+import { BASE_DAYS_IN_YEAR } from "./constants";
 
 export const TROS_INELIGIBLE_POWERUNITS = [...tros.ineligiblePowerUnitSubtypes];
 export const TROS_INELIGIBLE_TRAILERS = [...tros.ineligibleTrailerSubtypes];
@@ -9,3 +10,19 @@ export const MANDATORY_TROS_COMMODITIES: PermitCommodity[] =
     (commodity: PermitCommodity) =>
       commodity.condition === "CVSE-1000" || commodity.condition === "CVSE-1070"
   );
+
+export const MIN_TROS_DURATION = 30;
+export const TROS_DURATION_OPTIONS = [
+  { value: MIN_TROS_DURATION, label: "30 Days" },
+  { value: 60, label: "60 Days" },
+  { value: 90, label: "90 Days" },
+  { value: 120, label: "120 Days" },
+  { value: 150, label: "150 Days" },
+  { value: 180, label: "180 Days" },
+  { value: 210, label: "210 Days" },
+  { value: 240, label: "240 Days" },
+  { value: 270, label: "270 Days" },
+  { value: 300, label: "300 Days" },
+  { value: 330, label: "330 Days" },
+  { value: BASE_DAYS_IN_YEAR, label: "1 Year" },
+];

--- a/frontend/src/features/permits/constants/tros.ts
+++ b/frontend/src/features/permits/constants/tros.ts
@@ -1,6 +1,6 @@
 import { tros } from "./tros.json";
 import { PermitCommodity } from "../types/PermitCommodity";
-import { BASE_DAYS_IN_YEAR } from "./constants";
+import { COMMON_DURATION_OPTIONS, COMMON_MIN_DURATION } from "./constants";
 
 export const TROS_INELIGIBLE_POWERUNITS = [...tros.ineligiblePowerUnitSubtypes];
 export const TROS_INELIGIBLE_TRAILERS = [...tros.ineligibleTrailerSubtypes];
@@ -11,18 +11,5 @@ export const MANDATORY_TROS_COMMODITIES: PermitCommodity[] =
       commodity.condition === "CVSE-1000" || commodity.condition === "CVSE-1070"
   );
 
-export const MIN_TROS_DURATION = 30;
-export const TROS_DURATION_OPTIONS = [
-  { value: MIN_TROS_DURATION, label: "30 Days" },
-  { value: 60, label: "60 Days" },
-  { value: 90, label: "90 Days" },
-  { value: 120, label: "120 Days" },
-  { value: 150, label: "150 Days" },
-  { value: 180, label: "180 Days" },
-  { value: 210, label: "210 Days" },
-  { value: 240, label: "240 Days" },
-  { value: 270, label: "270 Days" },
-  { value: 300, label: "300 Days" },
-  { value: 330, label: "330 Days" },
-  { value: BASE_DAYS_IN_YEAR, label: "1 Year" },
-];
+export const MIN_TROS_DURATION = COMMON_MIN_DURATION;
+export const TROS_DURATION_OPTIONS = [...COMMON_DURATION_OPTIONS];

--- a/frontend/src/features/permits/constants/trow.ts
+++ b/frontend/src/features/permits/constants/trow.ts
@@ -1,23 +1,10 @@
 import { trow } from "./trow.json";
 import { PermitCommodity } from "../types/PermitCommodity";
-import { BASE_DAYS_IN_YEAR } from "./constants";
+import { COMMON_DURATION_OPTIONS, COMMON_MIN_DURATION } from "./constants";
 
 export const TROW_INELIGIBLE_POWERUNITS = [...trow.ineligiblePowerUnitSubtypes];
 export const TROW_INELIGIBLE_TRAILERS = [...trow.ineligibleTrailerSubtypes];
 export const TROW_COMMODITIES: PermitCommodity[] = [...trow.commodities];
 export const MANDATORY_TROW_COMMODITIES: PermitCommodity[] = [...TROW_COMMODITIES];
-export const MIN_TROW_DURATION = 30;
-export const TROW_DURATION_OPTIONS = [
-  { value: MIN_TROW_DURATION, label: "30 Days" },
-  { value: 60, label: "60 Days" },
-  { value: 90, label: "90 Days" },
-  { value: 120, label: "120 Days" },
-  { value: 150, label: "150 Days" },
-  { value: 180, label: "180 Days" },
-  { value: 210, label: "210 Days" },
-  { value: 240, label: "240 Days" },
-  { value: 270, label: "270 Days" },
-  { value: 300, label: "300 Days" },
-  { value: 330, label: "330 Days" },
-  { value: BASE_DAYS_IN_YEAR, label: "1 Year" },
-];
+export const MIN_TROW_DURATION = COMMON_MIN_DURATION;
+export const TROW_DURATION_OPTIONS = [...COMMON_DURATION_OPTIONS];

--- a/frontend/src/features/permits/constants/trow.ts
+++ b/frontend/src/features/permits/constants/trow.ts
@@ -1,7 +1,23 @@
 import { trow } from "./trow.json";
 import { PermitCommodity } from "../types/PermitCommodity";
+import { BASE_DAYS_IN_YEAR } from "./constants";
 
 export const TROW_INELIGIBLE_POWERUNITS = [...trow.ineligiblePowerUnitSubtypes];
 export const TROW_INELIGIBLE_TRAILERS = [...trow.ineligibleTrailerSubtypes];
 export const TROW_COMMODITIES: PermitCommodity[] = [...trow.commodities];
 export const MANDATORY_TROW_COMMODITIES: PermitCommodity[] = [...TROW_COMMODITIES];
+export const MIN_TROW_DURATION = 30;
+export const TROW_DURATION_OPTIONS = [
+  { value: MIN_TROW_DURATION, label: "30 Days" },
+  { value: 60, label: "60 Days" },
+  { value: 90, label: "90 Days" },
+  { value: 120, label: "120 Days" },
+  { value: 150, label: "150 Days" },
+  { value: 180, label: "180 Days" },
+  { value: 210, label: "210 Days" },
+  { value: 240, label: "240 Days" },
+  { value: 270, label: "270 Days" },
+  { value: 300, label: "300 Days" },
+  { value: 330, label: "330 Days" },
+  { value: BASE_DAYS_IN_YEAR, label: "1 Year" },
+];

--- a/frontend/src/features/permits/helpers/dateSelection.ts
+++ b/frontend/src/features/permits/helpers/dateSelection.ts
@@ -1,0 +1,25 @@
+import { MIN_TROS_DURATION, TROS_DURATION_OPTIONS } from "../constants/tros";
+import { MIN_TROW_DURATION, TROW_DURATION_OPTIONS } from "../constants/trow";
+import { PERMIT_TYPES, PermitType } from "../types/PermitType";
+
+/**
+ * Get list of selectable duration options for a given permit type.
+ * @param permitType Permit type to get duration options for
+ * @returns List of selectable duration options for the given permit type
+ */
+export const durationOptionsForPermitType = (permitType: PermitType) => {
+  if (permitType === PERMIT_TYPES.TROS) return TROS_DURATION_OPTIONS;
+  if (permitType === PERMIT_TYPES.TROW) return TROW_DURATION_OPTIONS;
+  return [];
+};
+
+/**
+ * Get the minimum allowable duration for a given permit type.
+ * @param permitType Permit type to get min duration for
+ * @returns Mininum allowable duration for the permit type
+ */
+export const minDurationForPermitType = (permitType: PermitType) => {
+  if (permitType === PERMIT_TYPES.TROS) return MIN_TROS_DURATION;
+  if (permitType === PERMIT_TYPES.TROW) return MIN_TROW_DURATION;
+  return 0;
+};

--- a/frontend/src/features/permits/helpers/deserializeApplication.ts
+++ b/frontend/src/features/permits/helpers/deserializeApplication.ts
@@ -5,6 +5,7 @@ import { Application, ApplicationResponseData } from "../types/application";
 import { getEndOfDate, getStartOfDate, now, toLocalDayjs, utcToLocalDayjs } from "../../../common/helpers/formatDate";
 import { getDurationOrDefault } from "./getDefaultApplicationFormData";
 import { getExpiryDate } from "./permitState";
+import { minDurationForPermitType } from "./dateSelection";
 
 /**
  * Deserializes an ApplicationResponseData object (received from backend) to an Application object
@@ -20,8 +21,9 @@ export const deserializeApplicationResponse = (
     getStartOfDate(now()),
   );
 
+  const permitType = response.permitType;
   const durationOrDefault = getDurationOrDefault(
-    30,
+    minDurationForPermitType(permitType),
     response.permitData.permitDuration,
   );
 

--- a/frontend/src/features/permits/helpers/getDefaultApplicationFormData.ts
+++ b/frontend/src/features/permits/helpers/getDefaultApplicationFormData.ts
@@ -11,6 +11,7 @@ import { PermitMailingAddress } from "../types/PermitMailingAddress";
 import { PermitContactDetails } from "../types/PermitContactDetails";
 import { PermitVehicleDetails } from "../types/PermitVehicleDetails";
 import { Application, ApplicationFormData } from "../types/application";
+import { minDurationForPermitType } from "./dateSelection";
 import {
   getEndOfDate,
   getStartOfDate,
@@ -171,7 +172,7 @@ export const getDefaultValues = (
   );
 
   const durationOrDefault = getDurationOrDefault(
-    30,
+    minDurationForPermitType(permitType),
     applicationData?.permitData?.permitDuration,
   );
 

--- a/frontend/src/features/permits/helpers/tests/permitState.test.ts
+++ b/frontend/src/features/permits/helpers/tests/permitState.test.ts
@@ -1,0 +1,46 @@
+import dayjs from "dayjs";
+
+import { getExpiryDate } from "../permitState";
+import { DATE_FORMATS, dayjsToLocalStr } from "../../../../common/helpers/formatDate";
+import { BASE_DAYS_IN_YEAR } from "../../constants/constants";
+
+describe("Permit States", () => {
+  it("yields correct expiry date given start date and non-year duration", () => {
+    // Arrange
+    const startDate = dayjs("2023-09-01");
+    const duration = 30;
+
+    // Act
+    const expiryDate = getExpiryDate(startDate, duration);
+    const expiryDateStr = dayjsToLocalStr(expiryDate, DATE_FORMATS.DATEONLY);
+
+    // Assert
+    expect(expiryDateStr).toBe("2023-09-30"); // +30 (-1) days
+  });
+
+  it("yields correct expiry date (before leap year Feb-29) given start date and 1-year duration", () => {
+    // Arrange
+    const startDate = dayjs("2023-02-28");
+    const duration = BASE_DAYS_IN_YEAR;
+
+    // Act
+    const expiryDate = getExpiryDate(startDate, duration);
+    const expiryDateStr = dayjsToLocalStr(expiryDate, DATE_FORMATS.DATEONLY);
+
+    // Assert
+    expect(expiryDateStr).toBe("2024-02-27"); // +365 (-1) days
+  });
+
+  it("yields correct expiry date for leap year given start date and 1-year duration", () => {
+    // Arrange
+    const startDate = dayjs("2023-03-01");
+    const duration = BASE_DAYS_IN_YEAR;
+
+    // Act
+    const expiryDate = getExpiryDate(startDate, duration);
+    const expiryDateStr = dayjsToLocalStr(expiryDate, DATE_FORMATS.DATEONLY);
+
+    // Assert
+    expect(expiryDateStr).toBe("2024-02-29"); // +366 (-1) days
+  });
+});

--- a/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
+++ b/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
@@ -3,7 +3,6 @@ import { FieldValues, FormProvider } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 
 import "./AmendPermitForm.scss";
-import { PERMIT_DURATION_OPTIONS } from "../../../constants/constants";
 import { usePermitVehicleManagement } from "../../../hooks/usePermitVehicleManagement";
 import { useAmendPermitForm } from "../hooks/useAmendPermitForm";
 import { SnackBarContext } from "../../../../../App";
@@ -29,6 +28,11 @@ import {
   useAmendPermit,
   useModifyAmendmentApplication,
 } from "../../../hooks/hooks";
+
+import {
+  durationOptionsForPermitType,
+  minDurationForPermitType,
+} from "../../../helpers/dateSelection";
 
 export const AmendPermitForm = () => {
   const {
@@ -181,10 +185,11 @@ export const AmendPermitForm = () => {
     }));
 
   const permitOldDuration = getDefaultRequiredVal(
-    30,
+    minDurationForPermitType(formData.permitType),
     permit?.permitData?.permitDuration,
   );
-  const durationOptions = PERMIT_DURATION_OPTIONS.filter(
+
+  const durationOptions = durationOptionsForPermitType(formData.permitType).filter(
     (duration) => duration.value <= permitOldDuration,
   );
 

--- a/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
+++ b/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
@@ -16,10 +16,10 @@ import OnRouteBCContext from "../../../../common/authentication/OnRouteBCContext
 import { PermitForm } from "./components/form/PermitForm";
 import { usePermitVehicleManagement } from "../../hooks/usePermitVehicleManagement";
 import { useCompanyInfoQuery } from "../../../manageProfile/apiManager/hooks";
-import { PERMIT_DURATION_OPTIONS } from "../../constants/constants";
 import { Nullable } from "../../../../common/types/common";
 import { PermitType } from "../../types/PermitType";
 import { PermitVehicleDetails } from "../../types/PermitVehicleDetails";
+import { durationOptionsForPermitType } from "../../helpers/dateSelection";
 import {
   applyWhenNotNullable,
   getDefaultRequiredVal,
@@ -249,7 +249,7 @@ export const ApplicationForm = ({ permitType }: { permitType: PermitType }) => {
           powerUnitSubTypes={powerUnitSubTypes}
           trailerSubTypes={trailerSubTypes}
           companyInfo={companyInfo}
-          durationOptions={PERMIT_DURATION_OPTIONS}
+          durationOptions={durationOptionsForPermitType(permitType)}
           doingBusinessAs={doingBusinessAs}
         />
       </FormProvider>

--- a/frontend/src/features/permits/pages/Application/components/form/tests/helpers/prepare.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/tests/helpers/prepare.tsx
@@ -14,6 +14,11 @@ import {
   now,
 } from "../../../../../../../../common/helpers/formatDate";
 
+import {
+  durationOptionsForPermitType,
+  minDurationForPermitType,
+} from "../../../../../../helpers/dateSelection";
+
 const feature = "testfeature";
 export const currentDt = getStartOfDate(now());
 export const tomorrow = dayjs(currentDt).add(1, "day");
@@ -28,25 +33,17 @@ export const maxFutureYear = maxFutureDate.year();
 export const maxFutureDay = maxFutureDate.date();
 export const daysInFutureMonth = maxFutureDate.daysInMonth();
 
-export const commodities = getDefaultCommodities(DEFAULT_PERMIT_TYPE);
-export const defaultDuration = 30;
+const permitType = DEFAULT_PERMIT_TYPE;
+export const commodities = getDefaultCommodities(permitType);
+export const defaultDuration = minDurationForPermitType(permitType);
 export const emptyCommodities: PermitCommodity[] = [];
-export const allDurations = [
-  { text: "30 Days", days: 30 },
-  { text: "60 Days", days: 60 },
-  { text: "90 Days", days: 90 },
-  { text: "120 Days", days: 120 },
-  { text: "150 Days", days: 150 },
-  { text: "180 Days", days: 180 },
-  { text: "210 Days", days: 210 },
-  { text: "240 Days", days: 240 },
-  { text: "270 Days", days: 270 },
-  { text: "300 Days", days: 300 },
-  { text: "330 Days", days: 330 },
-  { text: "1 Year", days: 365 },
-];
+export const allDurations = durationOptionsForPermitType(permitType)
+  .map(durationOption => ({
+    text: durationOption.label,
+    days: durationOption.value,
+  }));
 
-const mandatoryConditions = getMandatoryCommodities(DEFAULT_PERMIT_TYPE).map(commodity => commodity.condition);
+const mandatoryConditions = getMandatoryCommodities(permitType).map(commodity => commodity.condition);
 export const requiredCommodityIndices = commodities
   .map((commodity, i) =>
     mandatoryConditions.includes(commodity.condition)
@@ -60,8 +57,8 @@ const TestFormWrapper = (props: React.PropsWithChildren) => {
     defaultValues: {
       permitData: {
         startDate: currentDt,
-        permitDuration: 30,
-        expiryDate: getExpiryDate(currentDt, 30),
+        permitDuration: defaultDuration,
+        expiryDate: getExpiryDate(currentDt, defaultDuration),
         commodities: [],
       },
     },
@@ -90,7 +87,7 @@ export const renderTestComponent = (
           value: duration.days,
         }))}
         disableStartDate={false}
-        permitType={DEFAULT_PERMIT_TYPE}
+        permitType={permitType}
       />
     </TestFormWrapper>,
   );

--- a/frontend/src/features/permits/pages/Application/components/review/ReviewPermitDetails.tsx
+++ b/frontend/src/features/permits/pages/Application/components/review/ReviewPermitDetails.tsx
@@ -7,10 +7,10 @@ import { ReviewConditionsTable } from "./ReviewConditionsTable";
 import { DiffChip } from "./DiffChip";
 import { Nullable } from "../../../../../../common/types/common";
 import { PermitCommodity } from "../../../../types/PermitCommodity";
+import { BASE_DAYS_IN_YEAR } from "../../../../constants/constants";
 import {
   applyWhenNotNullable,
   areValuesDifferent,
-  getDefaultRequiredVal,
 } from "../../../../../../common/helpers/util";
 
 import {
@@ -89,7 +89,11 @@ export const ReviewPermitDetails = ({
             className="permit-dates__data"
             data-testid="permit-duration"
           >
-            {getDefaultRequiredVal(30, permitDuration)} Days
+            {applyWhenNotNullable(
+              (duration) => duration === BASE_DAYS_IN_YEAR ? "1 Year" : `${duration} Days`,
+              permitDuration,
+              "",
+            )}
           </Typography>
         </Box>
         <Box className="permit-expiry-banner">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Handle leap year scenarios (when to add 1 extra day for calculating expiry dates) when duration is 1 year
- Refactor hardcoded min allowable durations for permit types to use methods instead
- Fix and add new tests for handling leap year scenarios

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added 3 unit tests for method that calculates leap years (based on start date and duration), which should pass for normal scenarios as well as edge-case leap year scenarios as well.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1383-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1383-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1383-dops.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1383-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)