### PR TITLE
chore(ci): deprecate deploymentConfigs

### DIFF
--- a/charts/service/templates/deploymentconfig.yaml
+++ b/charts/service/templates/deploymentconfig.yaml
@@ -1,25 +1,15 @@
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ include "service.fullname" . }}
   labels:
     {{- include "service.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - {{ include "service.fullname" . }}
-        from:
-          kind: ImageStreamTag
-          name: {{ include "service.fullname" . }}:{{ .Values.image.tag }}
   selector:
     {{- include "service.selectorLabels" . | nindent 4 }}
   strategy:
-    type: Rolling
+    type: RollingUpdate
   template:
     metadata:
       annotations:

--- a/charts/service/templates/hpa.yaml
+++ b/charts/service/templates/hpa.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+    kind: Deployment
     name: {{ include "service.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}

--- a/database/templates/openshift.deploy.yml
+++ b/database/templates/openshift.deploy.yml
@@ -57,26 +57,16 @@ objects:
             name: ${REGISTRY}/${PROMOTE}
           referencePolicy:
             type: Local
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
       labels:
         app: ${NAME}-${ZONE}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:
@@ -87,7 +77,7 @@ objects:
           name: ${NAME}-${ZONE}-${COMPONENT}
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${NAME}-${ZONE}-${COMPONENT}
@@ -161,6 +151,6 @@ objects:
           protocol: TCP
           targetPort: 5432
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       sessionAffinity: None
       type: ClusterIP

--- a/database/templates/openshift.deploy.yml
+++ b/database/templates/openshift.deploy.yml
@@ -66,7 +66,8 @@ objects:
     spec:
       replicas: 1
       selector:
-        deployment: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:


### PR DESCRIPTION
OpenShift DeploymentConfigs have been deprecated in favour of Deployments.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1463-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1463-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1463-dops.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1463-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)