### PR TITLE
ORV2-2557: Fix permit start date validation bug

### DIFF
--- a/frontend/src/common/components/form/CustomFormComponents.tsx
+++ b/frontend/src/common/components/form/CustomFormComponents.tsx
@@ -6,8 +6,8 @@ import {
   RegisterOptions,
   useFormContext,
 } from "react-hook-form";
+
 import { ORBC_FormTypes } from "../../types/common";
-import { CustomDatePicker } from "./subFormComponents/CustomDatePicker";
 import { CustomOutlinedInput } from "./subFormComponents/CustomOutlinedInput";
 import { CustomSelect } from "./subFormComponents/CustomSelect";
 import { PhoneNumberInput } from "./subFormComponents/PhoneNumberInput";
@@ -17,7 +17,7 @@ import { CustomTextArea } from "./subFormComponents/CustomTextArea";
  * Properties of onRouteBC custom form components
  */
 export interface CustomFormComponentProps<T extends FieldValues> {
-  type: "input" | "select" | "phone" | "datePicker" | "textarea";
+  type: "input" | "select" | "phone" | "textarea";
   feature: string;
   options: CustomFormOptionsProps<T>;
   menuOptions?: JSX.Element[];
@@ -73,7 +73,7 @@ export const getErrorMessage = (errors: any, fieldPath: string): string => {
  * @param customHelperText Non-bold text to appear in parenthesis beside the label
  * @param menuOptions Menu items array for MUI Select component
  *
- * @returns An onRouteBc customized react form component
+ * @returns An onRouteBC customized react form component
  */
 export const CustomFormComponent = <T extends ORBC_FormTypes>({
   type,
@@ -139,15 +139,6 @@ export const CustomFormComponent = <T extends ORBC_FormTypes>({
             readOnly={readOnly}
           />
         );
-      case "datePicker":
-        return (
-          <CustomDatePicker
-            feature={feature}
-            name={name}
-            disabled={disabled}
-            readOnly={readOnly}
-          />
-        );
       case "textarea":
         return (
           <CustomTextArea
@@ -164,6 +155,7 @@ export const CustomFormComponent = <T extends ORBC_FormTypes>({
         return null;
     }
   };
+
   return (
     <Box sx={className ? null : { width }} className={className}>
       <Controller

--- a/frontend/src/common/components/form/subFormComponents/CustomDatePicker.scss
+++ b/frontend/src/common/components/form/subFormComponents/CustomDatePicker.scss
@@ -1,3 +1,68 @@
-@use "../CustomFormComponents";
+@import "../../../../themes/orbcStyles";
 
-@include CustomFormComponents.custom-form-component(".custom-date-picker");
+.custom-date-picker {
+  & &__form-control {
+    width: 100%;
+  }
+
+  & &__label {
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
+
+  & &__input-container {
+    z-index: 1;
+    color: $bc-black;
+    -webkit-text-fill-color: $bc-black;
+  }
+
+  &__picker {
+    &--disabled {
+      .custom-date-picker {
+        &__input-container {
+          z-index: 1;
+          color: $bc-black;
+          -webkit-text-fill-color: $bc-black;
+        }
+      }
+  
+      svg {
+        z-index: 1;
+      }
+  
+      fieldset {
+        background-color: $bc-background-light-grey;
+        border: 2px solid $bc-text-box-border-grey;
+      }
+    }
+
+    &.Mui-focused, & .Mui-focused {
+      fieldset {
+        border: 2px solid $focus-blue;
+      }
+    }
+
+    &--invalid.Mui-focused,
+    &--invalid .Mui-focused,
+    &--invalid,
+    .Mui-error {
+      fieldset {
+        border: 2px solid $bc-red;
+      }
+    }
+
+    fieldset {
+      border: 2px solid $bc-text-box-border-grey;   
+    }
+  }
+
+  &__helper-text {
+    .custom-date-picker &#{&}--warning {
+      color: $bc-black;
+    }
+
+    .custom-date-picker &#{&}--error {
+      color: $bc-red;
+    }
+  }
+}

--- a/frontend/src/common/components/form/subFormComponents/CustomDatePicker.tsx
+++ b/frontend/src/common/components/form/subFormComponents/CustomDatePicker.tsx
@@ -1,52 +1,80 @@
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { DatePicker, DateValidationError } from "@mui/x-date-pickers";
-import { useState, useEffect } from "react";
+import { Dayjs } from "dayjs";
+import { Box, FormControl, FormHelperText, FormLabel } from "@mui/material";
+import {
+  useState,
+  useEffect,
+} from "react";
+
 import {
   FieldValues,
   FieldPath,
   useFormContext,
   useController,
+  Controller,
+  RegisterOptions,
 } from "react-hook-form";
 
 import "./CustomDatePicker.scss";
-import { ORBC_FormTypes, RequiredOrNull } from "../../../types/common";
-import { now } from "../../../helpers/formatDate";
+import { Nullable, ORBC_FormTypes, RequiredOrNull } from "../../../types/common";
+import { getStartOfDate, now } from "../../../helpers/formatDate";
+import { getErrorMessage } from "../CustomFormComponents";
 import {
   invalidDate,
   invalidMaxStartDate,
   invalidPastStartDate,
 } from "../../../helpers/validationMessages";
 
-/**
- * Properties of the onrouteBC customized Date Picker MUI component
- */
+export const PAST_START_DATE_STATUSES = {
+  ALLOWED: "ALLOWED",
+  WARNING: "WARNING",
+  FAIL: "FAIL",
+} as const;
+
+export type PastStartDateStatus =
+  typeof PAST_START_DATE_STATUSES[keyof typeof PAST_START_DATE_STATUSES];
+
+// Properties of the onrouteBC customized Date Picker MUI component/
 export interface CustomDatePickerProps<T extends FieldValues> {
   feature: string;
   name: FieldPath<T>;
   disabled?: boolean;
   readOnly?: boolean;
+  className?: string;
+  rules: RegisterOptions;
+  label?: string;
+  pastStartDateStatus: PastStartDateStatus;
+  maxDaysInFuture?: number;
+  onChangeOverride?: (value: Dayjs | null) => void;
 }
 
-/**
- * An onRouteBC customized MUI Date Picker component
- * Based on https://mui.com/x/react-date-pickers/date-picker/
- *
- */
+// An onRouteBC customized MUI Date Picker component based
+// on https://mui.com/x/react-date-pickers/date-picker/
 export const CustomDatePicker = <T extends ORBC_FormTypes>({
   feature,
   name,
   disabled,
   readOnly,
+  className,
+  rules,
+  label,
+  pastStartDateStatus,
+  maxDaysInFuture,
+  onChangeOverride,
 }: CustomDatePickerProps<T>): JSX.Element => {
   const {
     trigger,
-    formState: { isSubmitted },
+    formState: { isSubmitted, errors },
     control,
   } = useFormContext();
 
-  // User can only select a date that is up to 14 days into the future of the current date
-  const maxDate = now().add(14, "day");
+  // If applicable, the user can only select a date that is up to
+  // max number of days into the future of the current date
+  const maxDate = maxDaysInFuture
+    ? now().add(maxDaysInFuture, "day")
+    : undefined;
 
   /**
    * DatePicker is tricky, because in theory, you have two components with event listeners.
@@ -65,70 +93,131 @@ export const CustomDatePicker = <T extends ORBC_FormTypes>({
    * There may be a better solution.
    * Reference: https://mui.com/x/react-date-pickers/validation/#show-the-error
    */
-  const { setError, clearErrors } = useFormContext();
-  const [muiError, setMuiError] =
+  const [dateError, setDateError] =
     useState<RequiredOrNull<DateValidationError>>(null);
-  const [errorMessage, setErrorMessage] = useState("");
+
+  const datePickerRules = {
+    ...rules,
+    validate: {
+      ...rules.validate,
+      disablePast: (value: Nullable<Dayjs>) => {
+        return pastStartDateStatus !== PAST_START_DATE_STATUSES.FAIL
+          || (dateError !== "disablePast" && dateError !== "minDate")
+          || !value
+          || (value.isAfter(getStartOfDate(now())))
+          || (value.isSame(getStartOfDate(now())))
+          || invalidPastStartDate();
+      },
+      maxDate: (value: Nullable<Dayjs>) => {
+        return !maxDaysInFuture
+          || (dateError !== "maxDate")
+          || !maxDate
+          || !value
+          || (value.isBefore(getStartOfDate(maxDate)))
+          || (value.isSame(getStartOfDate(maxDate)))
+          || invalidMaxStartDate(maxDaysInFuture);
+      },
+      invalidDate: () => {
+        return (dateError !== "invalidDate")
+          || invalidDate();
+      },
+    },
+  };
+
+  const handleDateChange = (value: Dayjs | null) => {
+    if (!onChangeOverride) {
+      onChange(value);
+      trigger(name);
+    } else {
+      onChangeOverride(value);
+    }
+  };
 
   useEffect(() => {
-    switch (muiError) {
-      case "minDate":
-      case "disablePast": {
-        setError(name, { type: "focus" }, { shouldFocus: true });
-        setErrorMessage(invalidPastStartDate());
-        break;
-      }
-      case "maxDate": {
-        setError(name, { type: "focus" }, { shouldFocus: true });
-        setErrorMessage(invalidMaxStartDate(14));
-        break;
-      }
-      case "invalidDate": {
-        setError(name, { type: "focus" }, { shouldFocus: true });
-        setErrorMessage(invalidDate());
-        break;
-      }
-      default: {
-        clearErrors(name);
-        setErrorMessage("");
-        break;
-      }
-    }
-  }, [muiError]);
+    // Revalidate whenever the date picker error is updated (new error or no errors)
+    trigger(name);
+  }, [dateError]);
+  
+  const rulesViolationMessage = getErrorMessage(errors, name);
+  const startDateWarningMessage =
+    (dateError === "minDate" || dateError === "disablePast")
+      && (pastStartDateStatus === PAST_START_DATE_STATUSES.WARNING)
+      ? invalidPastStartDate() : null;
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <DatePicker
-        className={`custom-date-picker ${disabled ? "custom-date-picker--disabled" : ""}`}
-        key={`${feature}-date-picker`}
-        ref={ref}
-        value={value}
-        disabled={disabled}
-        readOnly={readOnly}
-        onChange={onChange}
-        disablePast
-        maxDate={maxDate}
-        onError={(newError) => setMuiError(newError)}
-        slotProps={{
-          textField: {
-            helperText: errorMessage,
-            inputProps: {
-              className: "custom-date-picker__input-container",
-            },
-          },
-        }}
-        // This onClose function fixes a bug where the Select component does not immediately
-        // revalidate when selecting an option after an invalid form submission.
-        // The validation needed to be triggered again manually
-        onClose={async () => {
-          if (isSubmitted) {
-            const output = await trigger(name);
-            if (!output) {
-              trigger(name);
-            }
-          }
-        }}
+    <Box className={`custom-date-picker ${className ? className : ""}`}>
+      <Controller
+        key={`controller-${feature}-${name}`}
+        name={name}
+        control={control}
+        rules={datePickerRules}
+        render={({ fieldState: { invalid } }) => (
+          <FormControl
+            className="custom-date-picker__form-control"
+            margin="normal"
+            error={invalid}
+          >
+            <FormLabel
+              className="custom-date-picker__label"
+              id={`${feature}-${name}-label`}
+            >
+              {label}
+            </FormLabel>
+
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <DatePicker
+                className={`custom-date-picker__picker ${disabled ? "custom-date-picker__picker--disabled" : ""}`}
+                key={`${feature}-date-picker`}
+                ref={ref}
+                value={value}
+                disabled={disabled}
+                readOnly={readOnly}
+                onChange={(value) => handleDateChange(value)}
+                disablePast={pastStartDateStatus !== PAST_START_DATE_STATUSES.ALLOWED}
+                maxDate={maxDate}
+                onError={(dateValidationError) => setDateError(dateValidationError)}
+                slotProps={{
+                  textField: {
+                    inputProps: {
+                      className: "custom-date-picker__input-container",
+                    },
+                  },
+                }}
+                // This onClose function fixes a bug where the Select component does not immediately
+                // revalidate when selecting an option after an invalid form submission.
+                // The validation needed to be triggered again manually
+                onClose={async () => {
+                  if (isSubmitted) {
+                    const output = await trigger(name);
+                    if (!output) {
+                      trigger(name);
+                    }
+                  }
+                }}
+              />
+            </LocalizationProvider>
+
+            {rulesViolationMessage ? (
+              <FormHelperText
+                className="custom-date-picker__helper-text custom-date-picker__helper-text--error"
+                data-testid={`alert-${name}`}
+                error
+              >
+                {rulesViolationMessage}
+              </FormHelperText>
+            ) : null}
+
+            {startDateWarningMessage ? (
+              <FormHelperText
+                className="custom-date-picker__helper-text custom-date-picker__helper-text--warning"
+                data-testid={`custom-date-picker-${name}-warning`}
+              >
+                {startDateWarningMessage}
+              </FormHelperText>
+            ) : null}
+          </FormControl>
+        )}
       />
-    </LocalizationProvider>
+    </Box>
   );
 };

--- a/frontend/src/common/components/form/subFormComponents/CustomDatePicker.tsx
+++ b/frontend/src/common/components/form/subFormComponents/CustomDatePicker.tsx
@@ -200,7 +200,7 @@ export const CustomDatePicker = <T extends ORBC_FormTypes>({
             {rulesViolationMessage ? (
               <FormHelperText
                 className="custom-date-picker__helper-text custom-date-picker__helper-text--error"
-                data-testid={`alert-${name}`}
+                data-testid={`custom-date-picker-${name}-error`}
                 error
               >
                 {rulesViolationMessage}

--- a/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
+++ b/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
@@ -33,6 +33,7 @@ import {
   durationOptionsForPermitType,
   minDurationForPermitType,
 } from "../../../helpers/dateSelection";
+import { PAST_START_DATE_STATUSES } from "../../../../../common/components/form/subFormComponents/CustomDatePicker";
 
 export const AmendPermitForm = () => {
   const {
@@ -220,6 +221,7 @@ export const AmendPermitForm = () => {
           companyInfo={companyInfo}
           durationOptions={durationOptions}
           doingBusinessAs={doingBusinessAs}
+          pastStartDateStatus={PAST_START_DATE_STATUSES.WARNING}
         >
           <AmendRevisionHistory revisionHistory={revisionHistory} />
           <AmendReason feature={FEATURE} />

--- a/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
+++ b/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
@@ -31,6 +31,7 @@ import {
   APPLICATION_STEPS,
   ERROR_ROUTES,
 } from "../../../../routes/constants";
+import { PAST_START_DATE_STATUSES } from "../../../../common/components/form/subFormComponents/CustomDatePicker";
 
 /**
  * The first step in creating and submitting an Application.
@@ -48,8 +49,10 @@ export const ApplicationForm = ({ permitType }: { permitType: PermitType }) => {
     companyLegalName,
     userDetails,
     onRouteBCClientNumber,
+    idirUserDetails,
   } = useContext(OnRouteBCContext);
 
+  const isStaffUser = Boolean(idirUserDetails?.userAuthGroup);
   const companyInfoQuery = useCompanyInfoQuery();
   const companyInfo = companyInfoQuery.data;
 
@@ -267,6 +270,7 @@ export const ApplicationForm = ({ permitType }: { permitType: PermitType }) => {
           companyInfo={companyInfo}
           durationOptions={durationOptionsForPermitType(permitType)}
           doingBusinessAs={doingBusinessAs}
+          pastStartDateStatus={isStaffUser ? PAST_START_DATE_STATUSES.WARNING : PAST_START_DATE_STATUSES.FAIL}
         />
       </FormProvider>
 

--- a/frontend/src/features/permits/pages/Application/components/form/PermitDetails.scss
+++ b/frontend/src/features/permits/pages/Application/components/form/PermitDetails.scss
@@ -8,6 +8,10 @@
   & &__input-section {
     display: flex;
     gap: 2.5rem;
+
+    .custom-date-picker {
+      width: 344px;
+    }
   }
 
   & &__commodities {

--- a/frontend/src/features/permits/pages/Application/components/form/PermitDetails.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/PermitDetails.tsx
@@ -18,6 +18,7 @@ import { calculateFeeByDuration } from "../../../../helpers/feeSummary";
 import { PermitType } from "../../../../types/PermitType";
 import { Nullable } from "../../../../../../common/types/common";
 import { PermitCommodity } from "../../../../types/PermitCommodity";
+import { CustomDatePicker, PastStartDateStatus } from "../../../../../../common/components/form/subFormComponents/CustomDatePicker";
 import {
   PPC_EMAIL,
   TOLL_FREE_NUMBER,
@@ -37,6 +38,7 @@ export const PermitDetails = ({
   durationOptions,
   disableStartDate,
   permitType,
+  pastStartDateStatus,
 }: {
   feature: string;
   defaultStartDate: Dayjs;
@@ -49,6 +51,7 @@ export const PermitDetails = ({
   }[];
   disableStartDate: boolean;
   permitType: PermitType;
+  pastStartDateStatus: PastStartDateStatus;
 }) => {
   const { watch, register, setValue } = useFormContext();
 
@@ -90,19 +93,17 @@ export const PermitDetails = ({
 
       <Box className="permit-details__body">
         <Box className="permit-details__input-section">
-          <CustomFormComponent
-            type="datePicker"
+          <CustomDatePicker
             feature={feature}
-            options={{
-              name: "permitData.startDate",
-              rules: {
-                required: { value: true, message: requiredMessage() },
-              },
-              label: "Start Date",
-              width: PHONE_WIDTH,
-            }}
+            name="permitData.startDate"
             disabled={disableStartDate}
             readOnly={disableStartDate}
+            rules={{
+              required: { value: true, message: requiredMessage() },
+            }}
+            label="Start Date"
+            pastStartDateStatus={pastStartDateStatus}
+            maxDaysInFuture={14}
           />
 
           <CustomFormComponent

--- a/frontend/src/features/permits/pages/Application/components/form/PermitForm.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/PermitForm.tsx
@@ -12,6 +12,7 @@ import { PermitType } from "../../../../types/PermitType";
 import { Nullable } from "../../../../../../common/types/common";
 import { PermitVehicleDetails } from "../../../../types/PermitVehicleDetails";
 import { PermitCommodity } from "../../../../types/PermitCommodity";
+import { PastStartDateStatus } from "../../../../../../common/components/form/subFormComponents/CustomDatePicker";
 import {
   PowerUnit,
   Trailer,
@@ -49,6 +50,7 @@ interface PermitFormProps {
     label: string;
   }[];
   doingBusinessAs?: Nullable<string>;
+  pastStartDateStatus: PastStartDateStatus;
 }
 
 export const PermitForm = (props: PermitFormProps) => {
@@ -79,6 +81,7 @@ export const PermitForm = (props: PermitFormProps) => {
           durationOptions={props.durationOptions}
           disableStartDate={props.isAmendAction}
           permitType={props.permitType}
+          pastStartDateStatus={props.pastStartDateStatus}
         />
         
         <VehicleDetails

--- a/frontend/src/features/permits/pages/Application/components/form/tests/PermitDetails.test.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/tests/PermitDetails.test.tsx
@@ -2,6 +2,7 @@ import { PointerEventsCheckLevel } from "@testing-library/user-event";
 import dayjs from "dayjs";
 
 import { DATE_FORMATS } from "../../../../../../../common/helpers/formatDate";
+import { getExpiryDate } from "../../../../../helpers/permitState";
 import {
   commoditiesInfoBox,
   commodityConditionLabel,
@@ -9,8 +10,6 @@ import {
   dateOptions,
   durationOption,
   expiryDateElement,
-  invalidFutureDateMessageElement,
-  invalidPastDateMessageElement,
   lastMonthButton,
   nextMonthDateOptions,
   openDurationSelect,
@@ -38,11 +37,9 @@ import {
   renderTestComponent,
   defaultDuration,
   allDurations,
-  emptyCommodities,
   maxFutureYear,
   thisYear,
 } from "./helpers/prepare";
-import { getExpiryDate } from "../../../../../helpers/permitState";
 
 describe("Permit Details duration", () => {
   it("should have available durations to select", async () => {
@@ -184,29 +181,6 @@ describe("Permit Details start date", () => {
 
       expect(activeDates.length).toBe(1 + 14); // today and next 14 days
     }
-  });
-
-  it("should display error message for invalid past start dates", async () => {
-    // Arrange and Act
-    renderTestComponent(
-      dayjs(currentDt).subtract(1, "day"),
-      defaultDuration,
-      emptyCommodities,
-    );
-    // Assert
-    expect(await invalidPastDateMessageElement()).toBeVisible();
-  });
-
-  it("should display error message for invalid future start dates (more than 14 days from today)", async () => {
-    // Arrange and Act
-    renderTestComponent(
-      dayjs(currentDt).add(15, "day"),
-      defaultDuration,
-      emptyCommodities,
-    );
-
-    // Assert
-    expect(await invalidFutureDateMessageElement()).toBeVisible();
   });
 
   it("should display correct expiry date after selecting start date", async () => {

--- a/frontend/src/features/permits/pages/Application/components/form/tests/helpers/access.ts
+++ b/frontend/src/features/permits/pages/Application/components/form/tests/helpers/access.ts
@@ -81,11 +81,11 @@ export const selectDayFromDateOptions = async (
 };
 
 export const invalidPastDateMessageElement = async () => {
-  return await screen.findByText(/^Start date cannot be in the past/i);
+  return await screen.findByTestId("custom-date-picker-permitData.startDate-error");
 };
 
 export const invalidFutureDateMessageElement = async () => {
-  return await screen.findByText(/^Start date must be within 14 days/i);
+  return await screen.findByTestId("custom-date-picker-permitData.startDate-error");
 };
 
 export const commoditiesInfoBox = async () => {

--- a/frontend/src/features/permits/pages/Application/components/form/tests/helpers/prepare.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/tests/helpers/prepare.tsx
@@ -9,6 +9,7 @@ import { getDefaultCommodities, getMandatoryCommodities } from "../../../../../.
 import { PermitDetails } from "../../PermitDetails";
 import { getExpiryDate } from "../../../../../../helpers/permitState";
 import { PermitCommodity } from "../../../../../../types/PermitCommodity";
+import { PAST_START_DATE_STATUSES } from "../../../../../../../../common/components/form/subFormComponents/CustomDatePicker";
 import {
   getStartOfDate,
   now,
@@ -88,6 +89,7 @@ export const renderTestComponent = (
         }))}
         disableStartDate={false}
         permitType={permitType}
+        pastStartDateStatus={PAST_START_DATE_STATUSES.FAIL}
       />
     </TestFormWrapper>,
   );

--- a/frontend/src/features/settings/pages/SpecialAuthorizations/LOA/basic/LOABasicInfo.tsx
+++ b/frontend/src/features/settings/pages/SpecialAuthorizations/LOA/basic/LOABasicInfo.tsx
@@ -283,7 +283,7 @@ export const LOABasicInfo = ({
                 required: { value: true, message: requiredMessage() },
               }}
               label="Start Date"
-              pastStartDateStatus={PAST_START_DATE_STATUSES.FAIL}
+              pastStartDateStatus={PAST_START_DATE_STATUSES.ALLOWED}
               onChangeOverride={handleStartDateChange}
             />
 
@@ -295,7 +295,7 @@ export const LOABasicInfo = ({
               label="Expiry Date"
               disabled={neverExpires}
               readOnly={neverExpires}
-              pastStartDateStatus={PAST_START_DATE_STATUSES.FAIL}
+              pastStartDateStatus={PAST_START_DATE_STATUSES.ALLOWED}
               onChangeOverride={handleExpiryDateChange}
             />
           </div>

--- a/frontend/src/features/settings/pages/SpecialAuthorizations/LOA/basic/LOABasicInfo.tsx
+++ b/frontend/src/features/settings/pages/SpecialAuthorizations/LOA/basic/LOABasicInfo.tsx
@@ -23,6 +23,7 @@ import {
   selectionRequired,
   uploadSizeExceeded,
 } from "../../../../../../common/helpers/validationMessages";
+import { CustomDatePicker, PAST_START_DATE_STATUSES } from "../../../../../../common/components/form/subFormComponents/CustomDatePicker";
 
 const FEATURE = "loa";
 
@@ -144,6 +145,20 @@ export const LOABasicInfo = ({
     trigger("expiryDate");
   };
 
+  const handleStartDateChange = (startDate: Dayjs | null) => {
+    if (startDate) {
+      setValue("startDate", startDate);
+      trigger("startDate");
+      trigger("expiryDate");
+    }
+  };
+
+  const handleExpiryDateChange = (expiryDate: Dayjs | null) => {
+    setValue("expiryDate", expiryDate);
+    trigger("startDate");
+    trigger("expiryDate");
+  };
+
   const selectFile = (file: File) => {
     setValue("uploadFile", file);
     trigger("uploadFile");
@@ -260,30 +275,28 @@ export const LOABasicInfo = ({
 
         <div className="loa-basic-info__date-selection">
           <div className="loa-date-inputs">
-            <CustomFormComponent
+            <CustomDatePicker
               className="loa-date-inputs__start"
-              type="datePicker"
               feature={FEATURE}
-              options={{
-                name: "startDate",
-                rules: {
-                  required: { value: true, message: requiredMessage() },
-                },
-                label: "Start Date",
+              name="startDate"
+              rules={{
+                required: { value: true, message: requiredMessage() },
               }}
+              label="Start Date"
+              pastStartDateStatus={PAST_START_DATE_STATUSES.FAIL}
+              onChangeOverride={handleStartDateChange}
             />
 
-            <CustomFormComponent
+            <CustomDatePicker
               className="loa-date-inputs__expiry"
-              type="datePicker"
               feature={FEATURE}
-              options={{
-                name: "expiryDate",
-                rules: expiryRules,
-                label: "Expiry Date",
-              }}
+              name="expiryDate"
+              rules={expiryRules}
+              label="Expiry Date"
               disabled={neverExpires}
               readOnly={neverExpires}
+              pastStartDateStatus={PAST_START_DATE_STATUSES.FAIL}
+              onChangeOverride={handleExpiryDateChange}
             />
           </div>
           


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Refactor date picker components and fix date validation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] As company client, verify that creating/editing an application with a start date in the past (from the date time right now) is not allowed (will show error and not allow user to proceed to review page)
- [x] As staff user, verify that creating/editing/amending an application/permit with a start date in the past (from the date time right now) is allowed but will show warning message indicating that the selected date is in the past, and will still allow user to proceed to review page
- [x] When creating/editing an LOA, verify that all date rules still work as expected (ie. expiry date can't be before start date, expiry date is required when "never expires" checkbox isn't checked, start date cannot be in the past)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1528-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1528-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1528-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1528-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1528-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)