### PR TITLE
ORV2-2825 - FE: Update: Display suspend status on Staff search for company results

### DIFF
--- a/frontend/src/features/idir/search/components/IDIRCompanySearchResults.scss
+++ b/frontend/src/features/idir/search/components/IDIRCompanySearchResults.scss
@@ -41,4 +41,10 @@
       text-decoration: none;
     }
   }
+
+  &__cell {
+    .status-chip {
+      margin-left: 0.5rem;
+    }
+  }
 }

--- a/frontend/src/features/idir/search/components/IDIRCompanySearchResults.tsx
+++ b/frontend/src/features/idir/search/components/IDIRCompanySearchResults.tsx
@@ -25,6 +25,7 @@ import { Box, CardMedia, Stack, Typography } from "@mui/material";
 import { CustomActionLink } from "../../../../common/components/links/CustomActionLink";
 import { useNavigate } from "react-router-dom";
 import { VerifiedClient } from "../../../../common/authentication/types";
+import { StatusChip } from "../../../settings/components/creditAccount/StatusChip";
 
 /*
  *
@@ -158,13 +159,18 @@ export const IDIRCompanySearchResults = memo(
           header: "Company Name",
           enableSorting: true,
           sortingFn: "alphanumeric",
+          minSize: 220,
           Cell: (props: { row: any; cell: any }) => {
+            const isCompanySuspended = props.row.original.isSuspended;
             return (
-              <CustomActionLink
-                onClick={() => onClickCompany(props.row.original)}
-              >
-                {props.row.original.legalName}
-              </CustomActionLink>
+              <>
+                <CustomActionLink
+                  onClick={() => onClickCompany(props.row.original)}
+                >
+                  {props.row.original.legalName}
+                </CustomActionLink>
+                {isCompanySuspended && <StatusChip status="SUSPENDED" />}
+              </>
             );
           },
         },
@@ -207,6 +213,9 @@ export const IDIRCompanySearchResults = memo(
             children: "Error loading data",
           }
         : undefined,
+      muiTableBodyCellProps: {
+        className: "idir-company-search-results__cell",
+      },
     });
 
     return (


### PR DESCRIPTION
# Description

Show suspend status chip in IDIRCompanySearchResults when company is suspended

Fixes [#ORV2-2825](https://jira.th.gov.bc.ca/browse/ORV2-2825)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1599-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1599-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1599-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1599-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1599-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)