### PR TITLE
chore(ci): handle gh runner oc removal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,6 +148,11 @@ jobs:
           # If here skip deployment
           echo "No triggers have fired, deployment skipped"
 
+      - uses: redhat-actions/openshift-tools-installer@v1
+        if: ${{ steps.triggers.outputs.triggered == 'true' }}
+        with:
+          oc: "4"
+
       - name: Deploy if Triggers Fired
         if: ${{ steps.triggers.outputs.triggered == 'true' }}
         working-directory: ${{ inputs.directory }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   cleanup:
     name: Cleanup OpenShift and/or Promote Images
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@v0.6.1
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-close.yml@v0.7.1
     secrets:
       oc_namespace: ${{ vars.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -80,6 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+
       - name: Clean up Helm Releases
         run: |
           # Clean up Helm Releases


### PR DESCRIPTION
GitHub's latest runner has updated to 24.04, but they removed oc!  There'll also be incoming updates to actions via Renovate.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1625-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1625-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1625-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1625-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1625-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)