### PR TITLE
docs: Move database history table docs to git

### DIFF
--- a/database/mssql/scripts/generate-history-tables-and-triggers.sql
+++ b/database/mssql/scripts/generate-history-tables-and-triggers.sql
@@ -1,0 +1,370 @@
+SET XACT_ABORT, NOCOUNT ON
+
+-- --------------------------------------------------------------------------------------------
+-- Drop function fnFirsties 
+-- --------------------------------------------------------------------------------------------
+IF OBJECT_ID ( 'fnFirsties', 'FN' ) IS NOT NULL   
+  drop FUNCTION dbo.fnFirsties;
+go
+
+-- --------------------------------------------------------------------------------------------
+-- Create function fnFirsties 
+-- --------------------------------------------------------------------------------------------
+CREATE FUNCTION dbo.fnFirsties ( @str NVARCHAR(4000) )
+RETURNS NVARCHAR(max)
+AS
+BEGIN
+    DECLARE @retval NVARCHAR(2000);
+
+    SET @str    = RTRIM(LTRIM(@str));
+    SET @retval = LEFT(@str, 1);
+
+    WHILE CHARINDEX(' ',@str,1)>0 BEGIN
+        SET @str    = LTRIM(RIGHT(@str, LEN(@str) - CHARINDEX(' ', @str, 1)));
+        SET @retval = LEFT(@str, 1);
+    END
+
+    RETURN @retval;
+END
+GO
+
+-- --------------------------------------------------------------------------------------------
+-- Drop function fnGetColumnsString 
+-- --------------------------------------------------------------------------------------------
+IF OBJECT_ID ( 'fnGetColumnsString', 'FN' ) IS NOT NULL   
+  drop FUNCTION dbo.fnGetColumnsString;
+go
+
+-- --------------------------------------------------------------------------------------------
+-- Create function fnGetColumnsString 
+-- --------------------------------------------------------------------------------------------
+CREATE FUNCTION dbo.fnGetColumnsString ( @str NVARCHAR(4000) )
+RETURNS NVARCHAR(max)
+AS
+BEGIN
+  DECLARE @retval NVARCHAR(max) = '';
+
+  declare @statement_sql cursor
+  set @statement_sql = cursor for
+    select   COLUMN_NAME
+	         , data_type
+		       , CHARACTER_MAXIMUM_LENGTH
+		       , IS_NULLABLE 
+	  from     INFORMATION_SCHEMA.COLUMNS
+    where    TABLE_NAME                            =  @str
+	       and DATA_TYPE                             != 'varbinary' 
+		     and coalesce(character_maximum_length, 1) != -1
+    order by table_name
+	         , ORDINAL_POSITION;
+
+  declare @sql_txt1 nvarchar(max) = '';
+  declare @sql_txt2 nvarchar(max) = '';
+  declare @sql_txt3 nvarchar(max) = '';
+  declare @sql_txt4 nvarchar(max) = '';
+  
+  OPEN @statement_sql
+  
+  FETCH NEXT
+  FROM @statement_sql INTO @sql_txt1, @sql_txt2, @sql_txt3, @sql_txt4
+  
+  WHILE @@FETCH_STATUS = 0
+    BEGIN
+    set @retval += ', [' + @sql_txt1 + '] ' + @sql_txt2 + case when @sql_txt2 in ('char', 'nchar', 'varchar','nvarchar') then '(' + @sql_txt3 + ')' else '' end +case when @sql_txt4 = 'NO' then ' NOT' else ''  end+' NULL';
+    FETCH NEXT
+    FROM @statement_sql INTO @sql_txt1, @sql_txt2, @sql_txt3, @sql_txt4
+    END
+
+  CLOSE @statement_sql
+  DEALLOCATE @statement_sql
+
+  RETURN @retval;
+END
+GO
+
+--:OUT "G:\OneDrive\Documents\LMS Biz\Quartech\MOTI\PSP\Data Model\Build\Working\ORBC_generate_history_table.sql"
+
+begin
+declare @statement_sql cursor
+set @statement_sql = cursor for
+  select N'IF OBJECT_ID (''' + isnull(convert(varchar(max), p.value), stuff(dbo.fnFirsties(replace(t.name, '_', ' ')), 1, 1, '') + cast(row_number() over (order by t.name asc) as varchar(max))) + '_A_S_IUD_TR'', ''TR'') IS NOT NULL   
+  drop trigger ' + isnull(convert(varchar(max), p.value), stuff(dbo.fnFirsties(replace(t.name, '_', ' ')), 1, 1, '') + cast(row_number() over (order by t.name asc) as varchar(max))) + '_A_S_IUD_TR
+go
+
+IF OBJECT_ID (''' + t.name + '_HIST'', ''U'') IS NOT NULL   
+  drop table ' + t.name + '_HIST
+go
+
+IF OBJECT_ID (''' + t.name + '_H_ID_SEQ'', ''SO'') IS NOT NULL   
+  drop sequence ' + t.name + '_H_ID_SEQ
+go
+
+'
+from  sys.tables  t                                   join
+      sys.schemas s on s.schema_id = t.schema_id left join 
+      (select table_alias COLLATE catalog_default value
+            , table_name  COLLATE catalog_default table_name 
+       from   ORBCX_TableDefinitions) p on t.name COLLATE catalog_default = p.table_name COLLATE catalog_default,
+      INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc -- INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS ccu ON tc.CONSTRAINT_NAME = ccu.CONSTRAINT_NAME
+WHERE t.TYPE_desc        =        'USER_TABLE'
+  and t.NAME             like     'ORBC_%'
+  and tc.table_name      =        t.name
+  and tc.CONSTRAINT_TYPE =        'PRIMARY KEY'
+  and t.NAME             not like '%HIST'
+  and t.NAME             not like 'ORBCX%'
+  and t.NAME             not like '%EFMigration%'
+  and t.NAME             not like 'ETL%'
+  and t.NAME             not like 'PMBC%'
+  and t.NAME             not like '%SYS_VERS%'
+  -- code value (type and subtype) tables
+  and t.NAME             not like '%TYPE'
+  and t.NAME             not like '%SUBTYPE'
+  -- tables that do no have APP audit attributes
+  and t.name             !=       'ORBC_COUNTRY'
+  and t.name             !=       'ORBC_DISTRICT'
+  and t.name             !=       'ORBC_PROVINCE_STATE'
+  and t.name             !=       'ORBC_REGION'
+  and t.name             !=       'ORBC_TENANT'
+  and s.name             !=       'tps'
+order by t.name;  
+
+declare @sql_txt varchar(max) = '';
+
+OPEN @statement_sql
+
+FETCH NEXT
+FROM @statement_sql INTO @sql_txt
+
+WHILE @@FETCH_STATUS = 0
+    BEGIN
+    print @sql_txt
+    FETCH NEXT
+    FROM @statement_sql INTO @sql_txt
+    END
+
+CLOSE @statement_sql
+DEALLOCATE @statement_sql
+
+set @statement_sql = cursor for
+select N'CREATE SEQUENCE [' + s.name + '].[' + t.name + '_H_ID_SEQ] AS [bigint] START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 CACHE 50;
+
+CREATE TABLE [' + s.name + '].[' + t.name + '_HIST](
+  '+substring(t.name, 5, len(t.name)) + '_HIST_ID [bigint] DEFAULT (NEXT VALUE FOR [' + s.name + '].['  + t.name + '_H_ID_SEQ]) NOT NULL
+  ,EFFECTIVE_DATE_HIST [datetime] NOT NULL default getutcdate()
+  ,END_DATE_HIST [datetime]
+  '+dbo.fnGetColumnsString(t.name)+'
+  )
+ALTER TABLE [' + s.name + '].[' + t.name + '_HIST] ADD CONSTRAINT ' + isnull(convert(varchar(max), substring(cast(p.value as varchar), 1, 11)), 'ORBC_' + stuff(dbo.fnFirsties(replace(t.name, '_', ' ')), 1, 1, '') + cast(row_number() over (order by t.name asc) as varchar(max))) + '_H_PK PRIMARY KEY CLUSTERED (' + substring(t.name, 5, len(t.name)) + '_HIST_ID);  
+ALTER TABLE [' + s.name + '].[' + t.name + '_HIST] ADD CONSTRAINT ' + isnull(convert(varchar(max), substring(cast(p.value as varchar), 1, 11)), 'ORBC_' + stuff(dbo.fnFirsties(replace(t.name, '_', ' ')), 1, 1, '') + cast(row_number() over (order by t.name asc) as varchar(max))) + '_H_UK UNIQUE (' + substring(t.name, 5, len(t.name)) + '_HIST_ID,END_DATE_HIST)
+go
+
+'
+from  sys.tables  t                                   join
+      sys.schemas s on s.schema_id = t.schema_id left join
+      (select table_alias COLLATE catalog_default value
+            , table_name  COLLATE catalog_default table_name 
+       from   ORBCX_TableDefinitions) p on t.name COLLATE catalog_default = p.table_name COLLATE catalog_default,
+       INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc --INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS ccu ON tc.CONSTRAINT_NAME = ccu.CONSTRAINT_NAME
+WHERE t.TYPE_desc        =        'USER_TABLE'
+  and t.NAME             like     'ORBC_%'
+  and tc.table_name      =        t.name
+  and tc.CONSTRAINT_TYPE =        'PRIMARY KEY'
+  and t.NAME             not like '%HIST'
+  and t.NAME             not like 'ORBCX%'
+  and t.NAME             not like '%EFMigration%'
+  and t.NAME             not like 'ETL%'
+  and t.NAME             not like 'PMBC%'
+  and t.NAME             not like '%SYS_VERS%'
+  -- code value (type and subtype) tables
+  and t.NAME             not like '%TYPE'
+  and t.NAME             not like '%SUBTYPE'
+  -- tables that do no have APP audit attributes
+  and t.name             !=       'ORBC_COUNTRY'
+  and t.name             !=       'ORBC_DISTRICT'
+  and t.name             !=       'ORBC_PROVINCE_STATE'
+  and t.name             !=       'ORBC_REGION'
+  and t.name             !=       'ORBC_TENANT'
+  and s.name             !=       'tps'
+order by 1;
+
+OPEN @statement_sql
+FETCH NEXT
+FROM @statement_sql INTO @sql_txt
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    print @sql_txt
+    FETCH NEXT
+    FROM @statement_sql INTO @sql_txt
+END
+
+CLOSE @statement_sql
+DEALLOCATE @statement_sql
+
+end
+-- ............................................................................................
+
+--drop function dbo.fnFirsties;
+--drop function fnGetColumnsString;
+
+------------------------------------------------
+SET XACT_ABORT, NOCOUNT ON
+
+
+-- --------------------------------------------------------------------------------------------
+-- Drop function fnFirsties 
+-- --------------------------------------------------------------------------------------------
+IF OBJECT_ID ( 'fnFirsties', 'FN' ) IS NOT NULL   
+  drop FUNCTION dbo.fnFirsties;
+go
+-- ............................................................................................
+
+
+-- --------------------------------------------------------------------------------------------
+-- Create function fnFirsties 
+-- --------------------------------------------------------------------------------------------
+CREATE FUNCTION dbo.fnFirsties ( @str NVARCHAR(4000) )
+RETURNS NVARCHAR(max)
+AS
+BEGIN
+    DECLARE @retval NVARCHAR(2000);
+
+    SET @str=RTRIM(LTRIM(@str));
+    SET @retval=LEFT(@str,1);
+
+    WHILE CHARINDEX(' ',@str,1)>0 BEGIN
+        SET @str=LTRIM(RIGHT(@str,LEN(@str)-CHARINDEX(' ',@str,1)));
+        SET @retval+=LEFT(@str,1);
+    END
+
+    RETURN @retval;
+END
+GO
+-- ............................................................................................
+
+
+-- --------------------------------------------------------------------------------------------
+-- Drop function fnGetColumnsString2 
+-- --------------------------------------------------------------------------------------------
+IF OBJECT_ID ( 'fnGetColumnsString2', 'FN' ) IS NOT NULL   
+  drop FUNCTION dbo.fnGetColumnsString2;
+go
+-- ............................................................................................
+
+
+-- --------------------------------------------------------------------------------------------
+-- Create function fnGetColumnsString2 
+-- --------------------------------------------------------------------------------------------
+CREATE FUNCTION dbo.fnGetColumnsString2 ( @str NVARCHAR(4000) )
+RETURNS NVARCHAR(max)
+AS
+BEGIN
+  DECLARE @retval NVARCHAR(max) = '';
+
+  declare @statement_sql cursor
+  set @statement_sql = cursor for
+  select COLUMN_NAME from INFORMATION_SCHEMA.columns 
+    where TABLE_NAME = @str
+	and   DATA_TYPE != 'varbinary' and coalesce(character_maximum_length,1) != -1
+    order by table_name, ORDINAL_POSITION;
+
+  declare @sql_txt1 nvarchar(max) = '';
+  OPEN @statement_sql
+  FETCH NEXT
+  FROM @statement_sql INTO @sql_txt1
+  WHILE @@FETCH_STATUS = 0
+  begin
+    set @retval = @retval + '['+ @sql_txt1+'], ';
+  FETCH NEXT
+  FROM @statement_sql INTO @sql_txt1
+  END
+
+  CLOSE @statement_sql
+  DEALLOCATE @statement_sql
+
+  RETURN @retval;
+END
+GO
+-- ............................................................................................
+
+--:OUT "G:\OneDrive\Documents\LMS Biz\Quartech\MOTI\PSP\Data Model\Build\Working\ORBC_iud_trigger.sql"
+
+begin
+
+declare @statement_sql cursor
+declare @sql_txt varchar(max) = '';
+--declare @previous_sql_txt varchar(max) = '';
+
+set @statement_sql = cursor for
+select distinct N'CREATE TRIGGER '+isnull(convert(varchar(max),p.value), stuff(dbo.fnFirsties(replace(t.name,'_',' ')),1,1,'')+cast(row_number()over(order by t.name asc) as varchar(max)))+'_A_S_IUD_TR ON [' + s.name + '].[' + t.name + '] FOR INSERT, UPDATE, DELETE AS
+SET NOCOUNT ON
+BEGIN TRY
+DECLARE @curr_date datetime;
+SET @curr_date = getutcdate();
+  IF NOT EXISTS(SELECT * FROM inserted) AND NOT EXISTS(SELECT * FROM deleted) 
+    RETURN;
+
+  -- historical
+  IF EXISTS(SELECT * FROM deleted)
+    update [' + s.name + '].[' + t.name + '_HIST] set END_DATE_HIST = @curr_date where ' + ccu.COLUMN_NAME + ' in (select ' + ccu.COLUMN_NAME + ' from deleted) and END_DATE_HIST is null;
+  
+  IF EXISTS(SELECT * FROM inserted)
+    insert into [' + s.name + '].[' + t.name + '_HIST] (' + dbo.fnGetColumnsString2(t.name) + substring(t.name, 5, len(t.name)) + '_HIST_ID, END_DATE_HIST, EFFECTIVE_DATE_HIST)
+      select ' + dbo.fnGetColumnsString2(t.name) + '(next value for [' + s.name + '].[' + t.name + '_H_ID_SEQ]) as ['+substring(t.name, 5, len(t.name)) + '_HIST_ID], null as [END_DATE_HIST], @curr_date as [EFFECTIVE_DATE_HIST] from inserted;
+
+END TRY
+BEGIN CATCH
+   IF @@trancount > 0 ROLLBACK TRANSACTION
+   EXEC orbc_error_handling
+END CATCH;
+go
+
+'
+from  sys.tables  t                                   join
+      sys.schemas s on s.schema_id = t.schema_id left join
+      (select table_alias COLLATE catalog_default value
+            , table_name  COLLATE catalog_default table_name 
+       from   ORBCX_TableDefinitions) p on t.name COLLATE catalog_default = p.table_name COLLATE catalog_default,
+       INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc INNER JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE AS ccu ON tc.CONSTRAINT_NAME = ccu.CONSTRAINT_NAME
+WHERE t.TYPE_desc        =        'USER_TABLE'
+  and t.NAME             like     'ORBC_%'
+  and tc.table_name      =        t.name
+  and tc.CONSTRAINT_TYPE =        'PRIMARY KEY'
+  and t.NAME             not like '%HIST'
+  and t.NAME             not like 'ORBCX%'
+  and t.NAME             not like '%EFMigration%'
+  and t.NAME             not like 'ETL%'
+  and t.NAME             not like 'PMBC%'
+  and t.NAME             not like '%SYS_VERS%'
+  -- code value (type and subtype) tables
+  and t.NAME             not like '%TYPE'
+  and t.NAME             not like '%SUBTYPE'
+  -- tables that do no have APP audit attributes
+  and t.name             !=       'ORBC_COUNTRY'
+  and t.name             !=       'ORBC_DISTRICT'
+  and t.name             !=       'ORBC_PROVINCE_STATE'
+  and t.name             !=       'ORBC_REGION'
+  and t.name             !=       'ORBC_TENANT'
+  and s.name             !=       'tps'
+order by 1;
+
+OPEN @statement_sql
+FETCH NEXT
+FROM @statement_sql INTO @sql_txt
+WHILE @@FETCH_STATUS = 0
+BEGIN	
+	print @sql_txt	
+    FETCH NEXT
+    FROM @statement_sql INTO @sql_txt
+END
+
+CLOSE @statement_sql
+DEALLOCATE @statement_sql
+
+end
+
+-- --------------------------------------------------------------------------------------------
+-- Drop functions created earlier 
+-- --------------------------------------------------------------------------------------------
+
+drop function dbo.fnFirsties;
+drop function fnGetColumnsString;
+drop function fnGetColumnsString2;

--- a/database/mssql/scripts/history-tables-instructions.md
+++ b/database/mssql/scripts/history-tables-instructions.md
@@ -1,0 +1,35 @@
+# History Tables and Triggers
+MoTI database standards dictate a specific approach for maintaining history of database changes. This is handled in ORBC with 'mirror' history tables, named identically to the base table with a _HIST suffix.
+
+The history tables are populated on each insert, update, and delete operation via a trigger on the base table which inserts a new row into the history table for every action.
+
+The history tables rely on a database sequence to generate their unique identifier (as opposed to identity columns which are typically used in ORBC for this purpose in the base tables).
+
+## New Tables
+Each new table created in the ORBC database which is not a 'lookup' or 'type' table will need three additional objects created alongside: a history table, a trigger, and a sequence.
+
+For new tables, the SQL to generate these three objects can be retrieved by running the generate-history-tables-and-triggers.sql file in your local (docker) development database once the new business tables are in place. The .sql file will generate the DDL for all base tables in the database, not just the new ones you've added, so you will need to search the output for your new table name to find the three objects. You can ignore the rest.
+
+The name of the trigger that the .sql generates in the DDL is not appropriate - you will need to come up with an appropriate name for the trigger that is based on a shortened version of the base table name. Refer to the other triggers in the database for guidance - it isn't critical that it be done a certain way just that it be fairly consistent with the rest of the trigger names, and that it be unique in the database.
+
+## Updated Tables
+When a table is updated in ORBC to add or remove columns, to change the data type of the column, or to change a column from nullable to non-nullable, more manual effort is required.
+
+__Important__: when copying the DDL that's generated from the attached .sql script, __do not__ copy the 'drop table' or 'drop sequence' components. History tables, once modified, are to remain permanently in the database. For sequences, if it is dropped and re-created it will start at 1 again which will generate errors.
+
+### Column Additions
+New columns must be added to both the history table and the trigger. You can use the generated DDL for guidance with how to add it, or you can add it in manually if just one or two columns (probably easier that way).
+
+### Column Deletions
+Deleted columns must be removed from the trigger, but should remain in the history table. Never delete any columns with data from the history tables, they will remain in perpetuity.
+
+### Column Renames
+However the column rename is done in the base table DDL is how it should be done also in the history table DDL. The trigger will also need to be updated to reflect the new column name, though this is just a text modification to the trigger DDL and not as complex as the table rename.
+
+### Column Data Type Changes
+As with the column renames, the column data type changes must be done in the history table in the same way as it is done in the base table (avoidance of data loss / truncation is important). No changes need to be made to the trigger DDL.
+
+### Column NULL / NOT NULL Switches
+Columns changing from NOT NULL to NULL require that the same change be done to the history table. No changes are required to the trigger.
+
+Columns changing from NULL to NOT NULL require __no__ changes to the history table to avoid creating fake 'history' data where null is appropriate. No changes are required to the trigger.


### PR DESCRIPTION
# Description

Add documentation for creating history tables and triggers in the SQL database, moving from Confluence.

Fixes # ORV2-2761

## Type of change

- [X] Documentation update

# How Has This Been Tested?

N/A

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have already been accepted and merged



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1628-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1628-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1628-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1628-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1628-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)