### PR TITLE
ORV-2748 - Voided permits showing as expired in global search

### DIFF
--- a/frontend/src/features/idir/search/table/PermitSearchResultColumnDef.tsx
+++ b/frontend/src/features/idir/search/table/PermitSearchResultColumnDef.tsx
@@ -32,8 +32,6 @@ export const PermitSearchResultColumnDef = (
       const isPermitVoided = (permitStatus: PermitStatus) =>
         permitStatus === PERMIT_STATUSES.VOIDED;
 
-      console.log(isPermitVoided(permitStatus));
-
       return (
         <>
           <CustomActionLink

--- a/frontend/src/features/idir/search/table/PermitSearchResultColumnDef.tsx
+++ b/frontend/src/features/idir/search/table/PermitSearchResultColumnDef.tsx
@@ -3,7 +3,11 @@ import { MRT_ColumnDef } from "material-react-table";
 
 import { CustomActionLink } from "../../../../common/components/links/CustomActionLink";
 import { PermitListItem } from "../../../permits/types/permit";
-import { PERMIT_EXPIRED } from "../../../permits/types/PermitStatus";
+import {
+  PERMIT_EXPIRED,
+  PERMIT_STATUSES,
+  PermitStatus,
+} from "../../../permits/types/PermitStatus";
 import { PermitChip } from "../../../permits/components/permit-list/PermitChip";
 import { viewPermitPdf } from "../../../permits/helpers/permitPDFHelper";
 import { hasPermitExpired } from "../../../permits/helpers/permitState";
@@ -25,21 +29,23 @@ export const PermitSearchResultColumnDef = (
       const permit = props.row.original as PermitListItem;
       const { permitId, permitStatus, expiryDate, companyId } = permit;
 
+      const isPermitVoided = (permitStatus: PermitStatus) =>
+        permitStatus === PERMIT_STATUSES.VOIDED;
+
+      console.log(isPermitVoided(permitStatus));
+
       return (
         <>
           <CustomActionLink
-            onClick={() =>{
-              viewPermitPdf(
-                companyId,
-                permitId,
-                () => onDocumentUnavailable(),
-              );
-            }  
-          }
+            onClick={() => {
+              viewPermitPdf(companyId, permitId, () => onDocumentUnavailable());
+            }}
           >
             {props.cell.getValue()}
           </CustomActionLink>
-          {hasPermitExpired(expiryDate) ? (
+          {isPermitVoided(permitStatus) ? (
+            <PermitChip permitStatus={permitStatus} />
+          ) : hasPermitExpired(expiryDate) ? (
             <PermitChip permitStatus={PERMIT_EXPIRED} />
           ) : (
             <PermitChip permitStatus={permitStatus} />
@@ -54,13 +60,13 @@ export const PermitSearchResultColumnDef = (
     header: "Permit Type",
     enableSorting: true,
     sortingFn: "alphanumeric",
-    Cell: (props: { cell: any; }) => {
-      const permitTypeName = getPermitTypeName(props.cell.getValue())
-      return <Tooltip title={permitTypeName}>
-        <Box>
-          {props.cell.getValue()}
-        </Box>
-      </Tooltip>
+    Cell: (props: { cell: any }) => {
+      const permitTypeName = getPermitTypeName(props.cell.getValue());
+      return (
+        <Tooltip title={permitTypeName}>
+          <Box>{props.cell.getValue()}</Box>
+        </Tooltip>
+      );
     },
     size: 20,
   },

--- a/frontend/src/features/idir/search/table/PermitSearchResultColumnDef.tsx
+++ b/frontend/src/features/idir/search/table/PermitSearchResultColumnDef.tsx
@@ -29,8 +29,20 @@ export const PermitSearchResultColumnDef = (
       const permit = props.row.original as PermitListItem;
       const { permitId, permitStatus, expiryDate, companyId } = permit;
 
-      const isPermitVoided = (permitStatus: PermitStatus) =>
-        permitStatus === PERMIT_STATUSES.VOIDED;
+      const getDisplayedPermitStatus = (
+        permitStatus: PermitStatus,
+        expiryDate: string,
+      ) => {
+        if (permitStatus === PERMIT_STATUSES.VOIDED) {
+          return PERMIT_STATUSES.VOIDED;
+        }
+
+        if (hasPermitExpired(expiryDate)) {
+          return PERMIT_EXPIRED;
+        }
+
+        return permitStatus;
+      };
 
       return (
         <>
@@ -41,13 +53,9 @@ export const PermitSearchResultColumnDef = (
           >
             {props.cell.getValue()}
           </CustomActionLink>
-          {isPermitVoided(permitStatus) ? (
-            <PermitChip permitStatus={permitStatus} />
-          ) : hasPermitExpired(expiryDate) ? (
-            <PermitChip permitStatus={PERMIT_EXPIRED} />
-          ) : (
-            <PermitChip permitStatus={permitStatus} />
-          )}
+          <PermitChip
+            permitStatus={getDisplayedPermitStatus(permitStatus, expiryDate)}
+          />
         </>
       );
     },


### PR DESCRIPTION
# Description

update PermitSearchResultColumnDef to show PermitStatusChip with Void status if permit is both expired and voided

Fixes [#ORV2-2748](https://moti-imb.atlassian.net/browse/ORV2-2748?atlOrigin=eyJpIjoiNzFkMWQzOGVhNzIzNDA4ZTk2MzUwZjZiZGQ4NzU1M2IiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1636-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1636-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1636-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1636-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1636-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)