### PR TITLE
ORV2-2875 - Regression: Applications (TROS, TROW) - vehicle list doesn't scroll properly while option is selected.

### DIFF
--- a/frontend/src/features/manageVehicles/components/form/PowerUnitForm.tsx
+++ b/frontend/src/features/manageVehicles/components/form/PowerUnitForm.tsx
@@ -242,7 +242,7 @@ export const PowerUnitForm = ({
             )}
             className="power-unit-form__field"
           />
-          
+
           <CountryAndProvince
             feature={FEATURE}
             countryField="countryCode"

--- a/frontend/src/features/manageVehicles/components/form/TrailerForm.tsx
+++ b/frontend/src/features/manageVehicles/components/form/TrailerForm.tsx
@@ -69,6 +69,7 @@ export const TrailerForm = ({
 
   const onAddOrUpdateVehicle = async (data: FieldValues) => {
     if (isEditMode) {
+      console.log({ converted: Number(data.year) });
       const trailerToBeUpdated = data as Trailer;
       const result = await updateTrailerMutation.mutateAsync({
         companyId,
@@ -123,7 +124,7 @@ export const TrailerForm = ({
   const handleClose = () => {
     navigate(VEHICLES_ROUTES.TRAILER_TAB);
   };
-  
+
   const saveButtonText = isEditMode ? "Save" : "Add To Inventory";
 
   return (
@@ -272,7 +273,7 @@ export const TrailerForm = ({
             provinceClassName="trailer-form__field"
           />
         </div>
-        
+
         <Box className="trailer-form__actions">
           <Button
             key="cancel-save-vehicle-button"

--- a/frontend/src/features/manageVehicles/components/form/TrailerForm.tsx
+++ b/frontend/src/features/manageVehicles/components/form/TrailerForm.tsx
@@ -69,7 +69,6 @@ export const TrailerForm = ({
 
   const onAddOrUpdateVehicle = async (data: FieldValues) => {
     if (isEditMode) {
-      console.log({ converted: Number(data.year) });
       const trailerToBeUpdated = data as Trailer;
       const result = await updateTrailerMutation.mutateAsync({
         companyId,

--- a/frontend/src/features/permits/pages/Application/components/form/VehicleDetails/customFields/SelectVehicleDropdown.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/VehicleDetails/customFields/SelectVehicleDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Autocomplete,
   FormControl,
@@ -71,18 +71,18 @@ export const SelectVehicleDropdown = ({
     ineligibleTrailerSubtypes,
   );
 
-  const selectedOption = selectedVehicle
-    ? getDefaultRequiredVal(
-        null,
-        eligibleVehicles.find((vehicle) =>
-          selectedVehicle.vehicleType === VEHICLE_TYPES.TRAILER
-            ? vehicle.vehicleType === VEHICLE_TYPES.TRAILER &&
-              (vehicle as Trailer).trailerId === selectedVehicle.vehicleId
-            : vehicle.vehicleType === VEHICLE_TYPES.POWER_UNIT &&
-              (vehicle as PowerUnit).powerUnitId === selectedVehicle.vehicleId,
-        ),
-      )
-    : null;
+  const selectedOption = useMemo(() => {
+    return getDefaultRequiredVal(
+      null,
+      eligibleVehicles.find((vehicle) =>
+        selectedVehicle?.vehicleType === VEHICLE_TYPES.TRAILER
+          ? vehicle.vehicleType === VEHICLE_TYPES.TRAILER &&
+            (vehicle as Trailer).trailerId === selectedVehicle.vehicleId
+          : vehicle.vehicleType === VEHICLE_TYPES.POWER_UNIT &&
+            (vehicle as PowerUnit).powerUnitId === selectedVehicle?.vehicleId,
+      ),
+    );
+  }, [selectedVehicle, eligibleVehicles]);
 
   const [vehicleTextValue, setVehicleTextValue] = useState<string>("");
 
@@ -95,10 +95,7 @@ export const SelectVehicleDropdown = ({
   }, [selectedOption]);
 
   return (
-    <FormControl
-      margin="normal"
-      className="select-vehicle-dropdown"
-    >
+    <FormControl margin="normal" className="select-vehicle-dropdown">
       <FormLabel className="select-vehicle-dropdown__label">{label}</FormLabel>
       <Autocomplete
         id="application-select-vehicle"


### PR DESCRIPTION
# Description

memoize selectedOption constant to prevent unnecessary re-renders causing scrolling issue in SelectedVehicleDropdown.tsx

Fixes [#ORV2-2875](https://moti-imb.atlassian.net/browse/ORV2-2875?atlOrigin=eyJpIjoiNWJkMTE0ZTRjODFkNDgxZWI4OTdhODQ4MDJmNmFkOTEiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1638-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1638-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1638-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1638-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1638-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)