### PR TITLE
ORV2-3306 - FE: Refund by cheque requiring transaction ID

### DIFF
--- a/frontend/src/common/constants/validation_messages.json
+++ b/frontend/src/common/constants/validation_messages.json
@@ -163,7 +163,7 @@
   "transactionId": {
     "defaultMessage": "Invalid transaction ID",
     "length": {
-      "messageTemplate": "Transaction ID length must be no longer than :max characters",
+      "messageTemplate": "Maximum :max characters",
       "placeholders": [":max"]
     }
   }

--- a/frontend/src/features/permits/pages/Refund/RefundPage.tsx
+++ b/frontend/src/features/permits/pages/Refund/RefundPage.tsx
@@ -69,8 +69,15 @@ const transactionIdRules = {
         requiredMessage()
       );
     },
-    validateTransactionId: (value: Optional<string>) => {
-      return (value && value.length <= 15) || invalidTranactionIdLength(15);
+    validateTransactionId: (
+      value: Optional<string>,
+      formValues: RefundFormData,
+    ) => {
+      return (
+        !formValues.shouldUsePrevPaymentMethod ||
+        (value && value.length <= 15) ||
+        invalidTranactionIdLength(15)
+      );
     },
   },
 };
@@ -210,6 +217,7 @@ export const RefundPage = ({
     const usePrev = shouldUsePrev === "true";
     setShouldUsePrevPaymentMethod(usePrev);
     setValue("refundOnlineMethod", usePrev ? getRefundOnlineMethod() : "");
+    setValue("transactionId", "");
     clearErrors("transactionId");
   };
 
@@ -227,6 +235,7 @@ export const RefundPage = ({
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const formattedValue = filterNonNumericValue(e.target.value);
+    handleRefundMethodChange("true");
     setValue("transactionId", formattedValue, { shouldValidate: true });
   };
 


### PR DESCRIPTION
# Description

update validateTransactionId method, clear transactionId when Cheque is selected, select prevPaymentMethod when user types into transactionId field

Fixes #[ORV2-3306](https://moti-imb.atlassian.net/browse/ORV2-3306?atlOrigin=eyJpIjoiM2NhOTZlODE1YTlhNDExMzhmZGZiNmVmODk0Mjc0OTUiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1745-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1745-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1745-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1745-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1745-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)