### PR TITLE
Update onroute-policy-engine version to latest

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "material-react-table": "^2.13.3",
         "mui-nested-menu": "^3.4.0",
         "oidc-client-ts": "^3.1.0",
-        "onroute-policy-engine": "^1.5.0",
+        "onroute-policy-engine": "^1.6.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-error-boundary": "^4.1.2",
@@ -7661,9 +7661,9 @@
       }
     },
     "node_modules/onroute-policy-engine": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-1.5.0.tgz",
-      "integrity": "sha512-MAbbwtyJUGssrSOepZT0XpyfIKDaCDcNH3QxeybfvnGdd4Ly0sc+WawZoxraZJyo0dVDqt/5tFs8JAdGQQCdYw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-1.6.3.tgz",
+      "integrity": "sha512-EFLf04raC+QgJaq/13Fx2kLt/iSO3ih1WcYvm61zMk3VLcHranSBqxIE2/tsFiuUKqFNbnDlPLAYoE2ZUuSjyg==",
       "dependencies": {
         "dayjs": "^1.11.13",
         "json-rules-engine": "^7.2.1",
@@ -14923,9 +14923,9 @@
       }
     },
     "onroute-policy-engine": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-1.5.0.tgz",
-      "integrity": "sha512-MAbbwtyJUGssrSOepZT0XpyfIKDaCDcNH3QxeybfvnGdd4Ly0sc+WawZoxraZJyo0dVDqt/5tFs8JAdGQQCdYw==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-1.6.3.tgz",
+      "integrity": "sha512-EFLf04raC+QgJaq/13Fx2kLt/iSO3ih1WcYvm61zMk3VLcHranSBqxIE2/tsFiuUKqFNbnDlPLAYoE2ZUuSjyg==",
       "requires": {
         "dayjs": "^1.11.13",
         "json-rules-engine": "^7.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "material-react-table": "^2.13.3",
     "mui-nested-menu": "^3.4.0",
     "oidc-client-ts": "^3.1.0",
-    "onroute-policy-engine": "^1.5.0",
+    "onroute-policy-engine": "^1.6.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",


### PR DESCRIPTION
# Description

Update the npm onroute-policy-engine package to 1.6.3 from 1.5.0 to use the new policy configuration JSON

Fixes # ORV2-3420 (partial)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X] Ran through smoke test from claiming account, applying and paying for permit to validate correct functioning of policy engine

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have already been accepted and merged



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1874-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1874-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1874-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1874-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1874-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)