### PR TITLE
ORV2-3219 - Vehicle inventory tables sorting on vehicle type code instead of displayed vehicle type

### DIFF
--- a/frontend/src/features/manageVehicles/components/list/Columns.tsx
+++ b/frontend/src/features/manageVehicles/components/list/Columns.tsx
@@ -47,7 +47,7 @@ export const PowerUnitColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
   },
   ...CommonVehicleColumnDefinition,
   {
-    accessorKey: "transformedPowerUnitType",
+    accessorKey: "vehicleSubType",
     header: "Vehicle Sub-Type",
     size: 200,
   },
@@ -61,7 +61,7 @@ export const TrailerColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
   },
   ...CommonVehicleColumnDefinition,
   {
-    accessorKey: "transformedTrailerType",
+    accessorKey: "vehicleSubType",
     header: "Vehicle Sub-Type",
     size: 200,
   },

--- a/frontend/src/features/manageVehicles/components/list/Columns.tsx
+++ b/frontend/src/features/manageVehicles/components/list/Columns.tsx
@@ -1,9 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { MRT_ColumnDef } from "material-react-table";
-
-import { Vehicle, VEHICLE_TYPES } from "../../types/Vehicle";
+import { Vehicle } from "../../types/Vehicle";
 import { formatCellValuetoDatetime } from "../../../../common/helpers/tableHelper";
-import { transformVehicleCodeToSubtype } from "../../helpers/vehicleSubtypes";
 
 const CommonVehicleColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
   {
@@ -50,21 +47,9 @@ export const PowerUnitColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
   },
   ...CommonVehicleColumnDefinition,
   {
-    accessorKey: "powerUnitTypeCode",
+    accessorKey: "transformedPowerUnitType",
     header: "Vehicle Sub-Type",
     size: 200,
-    // sortingFn: (rowA, rowB, columnId) => {
-    //   const valueA = transformVehicleCodeToSubtype(
-    //     VEHICLE_TYPES.POWER_UNIT,
-    //     rowA.getValue(columnId),
-    //   );
-    //   const valueB = transformVehicleCodeToSubtype(
-    //     VEHICLE_TYPES.POWER_UNIT,
-    //     rowB.getValue(columnId),
-    //   );
-
-    //   return valueA.localeCompare(valueB);
-    // },
   },
   CreatedAtColumnDefinition,
 ];
@@ -76,7 +61,7 @@ export const TrailerColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
   },
   ...CommonVehicleColumnDefinition,
   {
-    accessorKey: "trailerTypeCode",
+    accessorKey: "transformedTrailerType",
     header: "Vehicle Sub-Type",
     size: 200,
   },

--- a/frontend/src/features/manageVehicles/components/list/Columns.tsx
+++ b/frontend/src/features/manageVehicles/components/list/Columns.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { MRT_ColumnDef } from "material-react-table";
 
-import { Vehicle } from "../../types/Vehicle";
+import { Vehicle, VEHICLE_TYPES } from "../../types/Vehicle";
 import { formatCellValuetoDatetime } from "../../../../common/helpers/tableHelper";
+import { transformVehicleCodeToSubtype } from "../../helpers/vehicleSubtypes";
 
 const CommonVehicleColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
   {
@@ -51,6 +53,18 @@ export const PowerUnitColumnDefinition: MRT_ColumnDef<Vehicle>[] = [
     accessorKey: "powerUnitTypeCode",
     header: "Vehicle Sub-Type",
     size: 200,
+    // sortingFn: (rowA, rowB, columnId) => {
+    //   const valueA = transformVehicleCodeToSubtype(
+    //     VEHICLE_TYPES.POWER_UNIT,
+    //     rowA.getValue(columnId),
+    //   );
+    //   const valueB = transformVehicleCodeToSubtype(
+    //     VEHICLE_TYPES.POWER_UNIT,
+    //     rowB.getValue(columnId),
+    //   );
+
+    //   return valueA.localeCompare(valueB);
+    // },
   },
   CreatedAtColumnDefinition,
 ];

--- a/frontend/src/features/manageVehicles/components/list/List.tsx
+++ b/frontend/src/features/manageVehicles/components/list/List.tsx
@@ -135,9 +135,6 @@ export const List = memo(
     const { mutateAsync: deleteTrailers, isError: deleteTrailersFailed } =
       useDeleteTrailersMutation();
 
-    const colTypeCodes = columns.filter(
-      (item) => item.accessorKey === `${vehicleType}TypeCode`,
-    );
     const newColumns = columns.filter(
       (item) => item.accessorKey !== `${vehicleType}TypeCode`,
     );
@@ -168,20 +165,6 @@ export const List = memo(
         };
       });
     }, [vehiclesData, transformVehicleCode]);
-
-    if (colTypeCodes?.length === 1) {
-      const colTypeCode = colTypeCodes?.at(0);
-      if (colTypeCode) {
-        // eslint-disable-next-line react/display-name
-        colTypeCode.Cell = ({ cell }) => {
-          return <div>{transformVehicleCode(cell.getValue<string>())}</div>;
-        };
-
-        const colDate = newColumns?.pop();
-        newColumns.push(colTypeCode);
-        if (colDate) newColumns.push(colDate);
-      }
-    }
 
     const onClickTrashIcon = useCallback(() => {
       setIsDeleteDialogOpen(() => true);

--- a/frontend/src/features/manageVehicles/components/list/List.tsx
+++ b/frontend/src/features/manageVehicles/components/list/List.tsx
@@ -89,6 +89,8 @@ export const List = memo(
       isPending: vehiclesPending,
     } = query;
 
+    console.log({ vehiclesData });
+
     const canEditVehicles = usePermissionMatrix({
       permissionMatrixKeys: {
         permissionMatrixFeatureKey: "MANAGE_VEHICLE_INVENTORY",
@@ -118,6 +120,8 @@ export const List = memo(
       () => getColumns(vehicleType),
       [],
     );
+
+    console.log({ columns });
 
     const snackBar = useContext(SnackBarContext);
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -149,6 +153,33 @@ export const List = memo(
           : trailerSubTypes.filter((value) => value.typeCode === code);
       return getDefaultRequiredVal("", vehicleSubtypesForCode?.at(0)?.type);
     };
+
+    const newVehiclesData = getDefaultRequiredVal([], vehiclesData).map(
+      (vehicle) => {
+        if (
+          vehicleType === VEHICLE_TYPES.POWER_UNIT &&
+          "powerUnitTypeCode" in vehicle
+        ) {
+          return {
+            ...vehicle,
+            powerUnitTypeCode: transformVehicleCode(vehicle.powerUnitTypeCode),
+          };
+        } else if (
+          vehicleType === VEHICLE_TYPES.TRAILER &&
+          "trailerTypeCode" in vehicle
+        ) {
+          return {
+            ...vehicle,
+            trailerTypeCode: transformVehicleCode(vehicle.trailerTypeCode),
+          };
+        }
+
+        // Fallback case
+        return vehicle;
+      },
+    );
+
+    console.log({ newVehiclesData });
 
     if (colTypeCodes?.length === 1) {
       const colTypeCode = colTypeCodes?.at(0);

--- a/frontend/src/features/manageVehicles/components/list/List.tsx
+++ b/frontend/src/features/manageVehicles/components/list/List.tsx
@@ -160,12 +160,11 @@ export const List = memo(
 
         return {
           ...vehicle,
-          transformedPowerUnitType: isPowerUnit
-            ? transformVehicleCode(vehicle.powerUnitTypeCode)
-            : undefined,
-          transformedTrailerType: isTrailer
-            ? transformVehicleCode(vehicle.trailerTypeCode)
-            : undefined,
+          vehicleSubType: isPowerUnit
+            ? transformVehicleCode(vehicle.powerUnitTypeCode) // Use transformed code for PowerUnit
+            : isTrailer
+              ? transformVehicleCode(vehicle.trailerTypeCode) // Use transformed code for Trailer
+              : undefined, // Default case if neither PowerUnit nor Trailer
         };
       });
     }, [vehiclesData, transformVehicleCode]);

--- a/frontend/src/features/manageVehicles/helpers/vehicleSubtypes.ts
+++ b/frontend/src/features/manageVehicles/helpers/vehicleSubtypes.ts
@@ -1,13 +1,9 @@
-import { getDefaultRequiredVal } from "../../../common/helpers/util";
 import { LCV_VEHICLE_SUBTYPES } from "../../permits/constants/constants";
-import { usePowerUnitSubTypesQuery } from "../hooks/powerUnits";
-import { useTrailerSubTypesQuery } from "../hooks/trailers";
 import {
   BaseVehicle,
   PowerUnit,
   Trailer,
   VEHICLE_TYPES,
-  VehicleType,
 } from "../types/Vehicle";
 
 /**
@@ -34,20 +30,4 @@ export const selectedVehicleSubtype = (vehicle: BaseVehicle) => {
     default:
       return "";
   }
-};
-
-export const transformVehicleCodeToSubtype = (
-  vehicleType: VehicleType,
-  code: string,
-) => {
-  const { data: powerUnitSubtypesData } = usePowerUnitSubTypesQuery();
-  const { data: trailerSubtypesData } = useTrailerSubTypesQuery();
-  const powerUnitSubTypes = getDefaultRequiredVal([], powerUnitSubtypesData);
-  const trailerSubTypes = getDefaultRequiredVal([], trailerSubtypesData);
-
-  const vehicleSubtypesForCode =
-    vehicleType === VEHICLE_TYPES.POWER_UNIT
-      ? powerUnitSubTypes.filter((value) => value.typeCode === code)
-      : trailerSubTypes.filter((value) => value.typeCode === code);
-  return getDefaultRequiredVal("", vehicleSubtypesForCode?.at(0)?.type);
 };

--- a/frontend/src/features/manageVehicles/helpers/vehicleSubtypes.ts
+++ b/frontend/src/features/manageVehicles/helpers/vehicleSubtypes.ts
@@ -1,9 +1,13 @@
+import { getDefaultRequiredVal } from "../../../common/helpers/util";
 import { LCV_VEHICLE_SUBTYPES } from "../../permits/constants/constants";
+import { usePowerUnitSubTypesQuery } from "../hooks/powerUnits";
+import { useTrailerSubTypesQuery } from "../hooks/trailers";
 import {
   BaseVehicle,
   PowerUnit,
   Trailer,
   VEHICLE_TYPES,
+  VehicleType,
 } from "../types/Vehicle";
 
 /**
@@ -30,4 +34,20 @@ export const selectedVehicleSubtype = (vehicle: BaseVehicle) => {
     default:
       return "";
   }
+};
+
+export const transformVehicleCodeToSubtype = (
+  vehicleType: VehicleType,
+  code: string,
+) => {
+  const { data: powerUnitSubtypesData } = usePowerUnitSubTypesQuery();
+  const { data: trailerSubtypesData } = useTrailerSubTypesQuery();
+  const powerUnitSubTypes = getDefaultRequiredVal([], powerUnitSubtypesData);
+  const trailerSubTypes = getDefaultRequiredVal([], trailerSubtypesData);
+
+  const vehicleSubtypesForCode =
+    vehicleType === VEHICLE_TYPES.POWER_UNIT
+      ? powerUnitSubTypes.filter((value) => value.typeCode === code)
+      : trailerSubTypes.filter((value) => value.typeCode === code);
+  return getDefaultRequiredVal("", vehicleSubtypesForCode?.at(0)?.type);
 };


### PR DESCRIPTION
# Description

Transforms vehicle subtype code prior to passing the vehicle data to MRT, resulting in the vehicle sub type column now sorting correctly.

Fixes [#ORV2-3219 ](https://moti-imb.atlassian.net/browse/ORV2-3219?atlOrigin=eyJpIjoiNDY1N2ZkNDA1MzBhNDE2ODljMzdiMDZiOWFlMmIwNWQiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1881-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1881-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1881-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1881-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1881-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)