### PR TITLE
ORV2-4111 - FE: Refund Amount and Refund Transaction ID inputs not showing in Transaction History Table

### DIFF
--- a/frontend/src/features/permits/pages/Refund/components/TransactionHistoryTable.tsx
+++ b/frontend/src/features/permits/pages/Refund/components/TransactionHistoryTable.tsx
@@ -341,7 +341,7 @@ export const TransactionHistoryTable = ({
         },
       },
     ],
-    [],
+    [totalRefundDue],
   );
 
   const table = useMaterialReactTable({
@@ -349,11 +349,14 @@ export const TransactionHistoryTable = ({
     columns: columns,
     data: validTransactionHistory,
     onRowSelectionChange: setRowSelection,
-    state: { ...defaultTableStateOptions, rowSelection },
+    state: {
+      ...defaultTableStateOptions,
+      rowSelection,
+      columnVisibility: { chequeRefund: totalRefundDue !== 0 },
+    },
     initialState: {
       ...defaultTableInitialStateOptions,
       showGlobalFilter: false,
-      columnVisibility: { chequeRefund: totalRefundDue !== 0 },
     },
     getRowId: (row: RefundFormData) => row.permitNumber,
     displayColumnDefOptions: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Add totalRefundDue to dependency array of columns variable, move chequeRefund column visibility into MRT state property from initialState property

Fixes [#ORV2-4111](https://moti-imb.atlassian.net/browse/ORV2-4111?atlOrigin=eyJpIjoiMjVmZWJkZDQxYTRlNDZhMTkyOGQxY2YwNzFjN2MyMmIiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1964-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1964-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1964-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1964-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1964-scheduler.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)