### PR TITLE
ORV2-3952: Allow multiple trailer subtypes to be selectable and displayed for STOS permits

### DIFF
--- a/frontend/src/common/hooks/useMemoizedSequence.ts
+++ b/frontend/src/common/hooks/useMemoizedSequence.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+import { areOrderedSequencesEqual } from "../helpers/equality";
+
+/**
+ * Hook that memoizes a sequence of objects.
+ * The memoized sequence only changes when the size or order of items in the sequence changes.
+ * eg. If sequence === [{a: 1}, {a: 2}], and later [{a: 2}, {a: 1}] is passed in,
+ * the hook returns the updated sequence [{a: 2}, {a: 1}].
+ * @param sequence Sequence of objects
+ * @param equalFn Function that determines whether or not two objects of the sequence are equal
+ * @returns Memoized sequence of objects
+ */
+export const useMemoizedSequence = <T>(
+  sequence: T[],
+  equalFn: (item1: T, item2: T) => boolean,
+) => {
+  const [sequenceItems, setSequenceItems] = useState<T[]>(sequence);
+
+  useEffect(() => {
+    if (!areOrderedSequencesEqual(
+      sequenceItems,
+      sequence,
+      equalFn,
+    )) {
+      setSequenceItems(sequence);
+    }
+  }, [sequence]);
+
+  return sequenceItems;
+};

--- a/frontend/src/features/permits/hooks/form/useApplicationFormContext.ts
+++ b/frontend/src/features/permits/hooks/form/useApplicationFormContext.ts
@@ -16,6 +16,7 @@ import { useApplicationFormUpdateMethods } from "./useApplicationFormUpdateMetho
 import { usePermittedCommodity } from "../usePermittedCommodity";
 import { DEFAULT_EMPTY_SELECT_VALUE } from "../../../../common/constants/constants";
 import { PermitVehicleDetails } from "../../types/PermitVehicleDetails";
+import { useMemoizedSequence } from "../../../../common/hooks/useMemoizedSequence";
 
 export const useApplicationFormContext = () => {
   const applicationFormContextData = useContext(ApplicationFormContext);
@@ -188,12 +189,11 @@ export const useApplicationFormContext = () => {
     selectedCommodity: permittedCommodity?.commodityType,
   });
 
-  const selectedVehicleConfigSubtypes = useMemoizedArray(
+  const selectedVehicleConfigSubtypes = useMemoizedSequence(
     getDefaultRequiredVal(
       [],
       vehicleConfiguration?.trailers?.map(({ vehicleSubType }) => vehicleSubType),
     ),
-    (subtype) => subtype,
     (subtype1, subtype2) => subtype1 === subtype2,
   );
 

--- a/frontend/src/features/permits/hooks/useVehicleConfiguration.ts
+++ b/frontend/src/features/permits/hooks/useVehicleConfiguration.ts
@@ -63,7 +63,7 @@ export const useVehicleConfiguration = (
     const nextAllowed = getNextAllowedVehicleSubtypes(
       selectedCommodity,
       [selectedPowerUnitSubtype, ...selectedSubtypes],
-    ).filter(({ value }) => !selectedSubtypes.includes(value));
+    );
 
     // Sort next allowed subtypes so that if the option "None" is present, it appears at the very beginning
     const hasNoneOption = nextAllowed.find(subtypeOption => subtypeOption.value === "NONEXXX");

--- a/frontend/src/features/permits/pages/Application/components/common/SelectedVehicleSubtypeList.tsx
+++ b/frontend/src/features/permits/pages/Application/components/common/SelectedVehicleSubtypeList.tsx
@@ -31,9 +31,9 @@ export const SelectedVehicleSubtypeList = ({
         </TableHead>
 
         <TableBody>
-          {selectedSubtypesDisplay.map((subtype) => (
+          {selectedSubtypesDisplay.map((subtype, subtypeIndex) => (
             <TableRow
-              key={subtype}
+              key={`${subtype}-${subtypeIndex}`}
               className="selected-vehicle-subtype-list__row"
             >
               <TableCell

--- a/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/AddTrailer.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/AddTrailer.tsx
@@ -15,6 +15,7 @@ import { getDefaultRequiredVal } from "../../../../../../../common/helpers/util"
 import { ApplicationFormContext } from "../../../../../context/ApplicationFormContext";
 import { SelectedVehicleSubtypeList } from "../../common/SelectedVehicleSubtypeList";
 import { isTrailerSubtypeNone } from "../../../../../../manageVehicles/helpers/vehicleSubtypes";
+import { useMemoizedSequence } from "../../../../../../../common/hooks/useMemoizedSequence";
 import {
   DEFAULT_EMPTY_SELECT_VALUE,
   DEFAULT_SELECT_OPTIONS,
@@ -45,7 +46,7 @@ export const AddTrailer = ({
     (option1, option2) => option1.value === option2.value && option1.label === option2.label,
   );
 
-  const selectedSubtypesDisplay = useMemoizedArray(
+  const selectedSubtypesDisplay = useMemoizedSequence(
     selectedTrailerSubtypes.map(subtype => {
       if (isTrailerSubtypeNone(subtype)) return "None";
       return getDefaultRequiredVal(
@@ -53,7 +54,6 @@ export const AddTrailer = ({
         trailerSubtypeNamesMap.get(subtype),
       );
     }),
-    (selectedSubtype) => selectedSubtype,
     (subtype1, subtype2) => subtype1 === subtype2,
   );
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Allow user to be able to select multiple trailer subtypes for STOS permits, and allow the selected subtypes to be displayed multiple times (rather than only once)
- If a user has already selected a trailer subtype, and that subtype is still deemed selectable by the policy engine, then that subtype should again appear in the dropdown as a selectable option

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ensure that all the STOS behaviour still works as before, except for the trailer subtype selection part
- [x] With an STOS application, choose "Empty" as the commodity, and fill in the vehicle details with a power unit subtype of "Picker Truck Tractors", and observe that after selecting "Jeep" in the trailer subtype dropdown, you can again select "Jeep" as one of the next selectable dropdown options. Also, if you select "Jeep" again, observe that the table will now display your two selected "Jeep" subtypes.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-1967-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-1967-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-1967-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-1967-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-1967-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-1967-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)