### PR TITLE
ORV2-4036: Disable STOS Add Power Unit Button when Commodity Not Chosen

### DIFF
--- a/frontend/src/features/permits/pages/Application/components/form/CommodityDetailsSection/ChangeCommodityTypeDialog.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/CommodityDetailsSection/ChangeCommodityTypeDialog.tsx
@@ -41,7 +41,7 @@ export const ChangeCommodityTypeDialog = ({
 
       <DialogContent className="change-commodity-type-dialog__content">
         <Typography className="change-commodity-type-dialog__warning-msg">
-          Changing your commodity will require you to re-enter your vehicle information.
+          Changing your commodity will require you to re-enter your vehicle information and loaded dimensions.
         </Typography> 
       </DialogContent>
 

--- a/frontend/src/features/permits/pages/Application/components/form/CommodityDetailsSection/CommodityDetailsSection.scss
+++ b/frontend/src/features/permits/pages/Application/components/form/CommodityDetailsSection/CommodityDetailsSection.scss
@@ -13,7 +13,7 @@
     }
 
     &--commodity-type {
-      margin: 0;
+      margin: 1rem 0 0 0;
       width: 100%;
     }
   }

--- a/frontend/src/features/permits/pages/Application/components/form/CommodityDetailsSection/CommodityDetailsSection.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/CommodityDetailsSection/CommodityDetailsSection.tsx
@@ -79,6 +79,10 @@ export const CommodityDetailsSection = ({
       </Box>
 
       <Box className="commodity-details-section__body">
+        <h4>
+          The commodity type must be chosen before adding vehicle information.
+        </h4>
+
         <Controller
           name="permitData.permittedCommodity.commodityType"
           rules={{

--- a/frontend/src/features/permits/pages/Application/components/form/PermitForm.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/PermitForm.tsx
@@ -124,6 +124,7 @@ export const PermitForm = () => {
           powerUnitSubtypeNamesMap={powerUnitSubtypeNamesMap}
           trailerSubtypeNamesMap={trailerSubtypeNamesMap}
           selectedConfigSubtypes={selectedVehicleConfigSubtypes}
+          selectedCommodityType={commodityType}
           onSetSaveVehicle={onToggleSaveVehicle}
           onSetVehicle={onSetVehicle}
           onClearVehicle={onClearVehicle}

--- a/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/VehicleInformationSection.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/VehicleInformationSection.tsx
@@ -20,7 +20,8 @@ import { AddTrailer } from "./AddTrailer";
 import { VehicleInConfiguration } from "../../../../../types/PermitVehicleConfiguration";
 import { requiredPowerUnit } from "../../../../../../../common/helpers/validationMessages";
 import { ApplicationFormData } from "../../../../../types/application";
-import { ORBCFormFeatureType } from "../../../../../../../common/types/common";
+import { Nullable, ORBCFormFeatureType } from "../../../../../../../common/types/common";
+import { DEFAULT_EMPTY_SELECT_VALUE } from "../../../../../../../common/constants/constants";
 
 export const VehicleInformationSection = ({
   permitType,
@@ -34,6 +35,7 @@ export const VehicleInformationSection = ({
   powerUnitSubtypeNamesMap,
   trailerSubtypeNamesMap,
   selectedConfigSubtypes,
+  selectedCommodityType,
   onSetSaveVehicle,
   onSetVehicle,
   onClearVehicle,
@@ -53,6 +55,7 @@ export const VehicleInformationSection = ({
   powerUnitSubtypeNamesMap: Map<string, string>;
   trailerSubtypeNamesMap: Map<string, string>;
   selectedConfigSubtypes: string[];
+  selectedCommodityType?: Nullable<string>;
   onSetSaveVehicle: (saveVehicle: boolean) => void;
   onSetVehicle: (vehicleDetails: PermitVehicleDetails) => void;
   onClearVehicle: (saveVehicle: boolean) => void;
@@ -69,6 +72,9 @@ export const VehicleInformationSection = ({
     `vehicle-information-section__info-banner` +
     `${isSingleTrip ? " vehicle-information-section__info-banner--single-trip" : ""}`;
 
+  const isCommodityTypeSelected =
+    Boolean(selectedCommodityType) && (selectedCommodityType !== DEFAULT_EMPTY_SELECT_VALUE);
+
   const isPowerUnitSelectedForSingleTrip =
     isSingleTrip && Boolean(vehicleFormData.vin);
 
@@ -79,7 +85,7 @@ export const VehicleInformationSection = ({
   const { clearErrors } = useFormContext<ApplicationFormData>();
 
   const handleClickAddPowerUnit = () => {
-    if (isPowerUnitSelectedForSingleTrip) return;
+    if (isPowerUnitSelectedForSingleTrip || !isCommodityTypeSelected) return;
     setShowAddPowerUnitDialog(true);
   };
 
@@ -142,7 +148,7 @@ export const VehicleInformationSection = ({
                     aria-label="Add Power Unit"
                     variant="contained"
                     color="tertiary"
-                    disabled={isPowerUnitSelectedForSingleTrip}
+                    disabled={isPowerUnitSelectedForSingleTrip || !isCommodityTypeSelected}
                     onClick={handleClickAddPowerUnit}
                   >
                     <FontAwesomeIcon


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Disable STOS "Add Power Unit" button when commodity has not been chosen
- Update to commodity section and dialog text

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ensure that all existing STOS related application features still work as intended
- [x] When creating a new STOS application, and whenever removing/clearing the commodity section of a STOS permit application, verify that anytime the commodity is empty (or in the "Select" empty state), the "Add Power Unit" button is disabled, and the button is enabled only when a commodity has been chosen and a power unit vehicle has not yet been chosen.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
