### PR TITLE
ORV2-4373 - FE: Limit Refund Transaction ID input to 11 characters

### DIFF
--- a/frontend/src/features/permits/pages/Refund/components/RefundTransactionIdInput.tsx
+++ b/frontend/src/features/permits/pages/Refund/components/RefundTransactionIdInput.tsx
@@ -3,7 +3,10 @@ import { RefundFormData } from "../types/RefundFormData";
 import { Controller, useFormContext } from "react-hook-form";
 import { useEffect } from "react";
 import { NumberInput } from "../../../../../common/components/form/subFormComponents/NumberInput";
-import { requiredMessage } from "../../../../../common/helpers/validationMessages";
+import {
+  invalidTranactionIdLength,
+  requiredMessage,
+} from "../../../../../common/helpers/validationMessages";
 
 export const RefundTransactionIdInput = ({
   cell,
@@ -50,6 +53,10 @@ export const RefundTransactionIdInput = ({
           value:
             refundAmount !== "" && Number(refundAmount) !== 0 && !chequeRefund,
           message: requiredMessage(),
+        },
+        maxLength: {
+          value: 11,
+          message: invalidTranactionIdLength(11),
         },
       }}
       render={({ fieldState: { error } }) => (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

add max length validation of 11 to refund transaction id input in TransactionHistoryTable

Fixes [#ORV2-4373](https://moti-imb.atlassian.net/browse/ORV2-4373?atlOrigin=eyJpIjoiMmEyZGRlMGEyZTc1NDRmZGE0MzdkODdkMDYyYjkyYjAiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2025-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2025-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2025-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2025-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2025-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2025-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)