### PR TITLE
ORV2-4374 - FE: Limit Refund Transaction ID input to 15 characters

### DIFF
--- a/frontend/src/features/permits/pages/Application/components/pay/paymentOptions/IcepayPaymentOption.tsx
+++ b/frontend/src/features/permits/pages/Application/components/pay/paymentOptions/IcepayPaymentOption.tsx
@@ -13,7 +13,10 @@ import {
   DEFAULT_EMPTY_CARD_TYPE,
   PaymentMethodData,
 } from "../types/PaymentMethodData";
-import { requiredMessage } from "../../../../../../../common/helpers/validationMessages";
+import {
+  invalidTranactionIdLength,
+  requiredMessage,
+} from "../../../../../../../common/helpers/validationMessages";
 import { Nullable } from "../../../../../../../common/types/common";
 import { getErrorMessage } from "../../../../../../../common/components/form/CustomFormComponents";
 import {
@@ -82,6 +85,10 @@ const transactionIdRules = {
         requiredMessage()
       );
     },
+  },
+  maxLength: {
+    value: 15,
+    message: invalidTranactionIdLength(15),
   },
 };
 

--- a/frontend/src/features/permits/pages/Application/components/pay/paymentOptions/InPersonPPCPaymentOption.tsx
+++ b/frontend/src/features/permits/pages/Application/components/pay/paymentOptions/InPersonPPCPaymentOption.tsx
@@ -22,7 +22,10 @@ import {
 } from "../types/PaymentMethodData";
 import { Controller, useFormContext } from "react-hook-form";
 import { Nullable } from "../../../../../../../common/types/common";
-import { requiredMessage } from "../../../../../../../common/helpers/validationMessages";
+import {
+  invalidTranactionIdLength,
+  requiredMessage,
+} from "../../../../../../../common/helpers/validationMessages";
 import { getErrorMessage } from "../../../../../../../common/components/form/CustomFormComponents";
 import "./InPersonPPCPaymentOption.scss";
 
@@ -120,6 +123,10 @@ export const InPersonPPCPaymentOption = ({
           requiredMessage()
         );
       },
+    },
+    maxLength: {
+      value: 15,
+      message: invalidTranactionIdLength(15),
     },
   };
 

--- a/frontend/src/features/permits/pages/Refund/components/RefundTransactionIdInput.tsx
+++ b/frontend/src/features/permits/pages/Refund/components/RefundTransactionIdInput.tsx
@@ -56,7 +56,7 @@ export const RefundTransactionIdInput = ({
         },
         maxLength: {
           value: 11,
-          message: invalidTranactionIdLength(11),
+          message: invalidTranactionIdLength(15),
         },
       }}
       render={({ fieldState: { error } }) => (

--- a/frontend/src/features/permits/pages/Refund/components/RefundTransactionIdInput.tsx
+++ b/frontend/src/features/permits/pages/Refund/components/RefundTransactionIdInput.tsx
@@ -55,7 +55,7 @@ export const RefundTransactionIdInput = ({
           message: requiredMessage(),
         },
         maxLength: {
-          value: 11,
+          value: 15,
           message: invalidTranactionIdLength(15),
         },
       }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

update maximum refund transaction id length to 15

Fixes [#ORV2-4374](https://moti-imb.atlassian.net/browse/ORV2-4374?atlOrigin=eyJpIjoiMmQxMzIxNjk3MDg0NDA3MDg1MGFmYTcyNjBhMDY1ODEiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2027-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2027-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2027-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2027-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2027-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2027-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)