### PR TITLE
ORV2-4329: Only TROS and STOS should attach LCV T-forms

### DIFF
--- a/frontend/src/features/permits/helpers/conditions.ts
+++ b/frontend/src/features/permits/helpers/conditions.ts
@@ -10,6 +10,20 @@ import { PermitCondition } from "../types/PermitCondition";
 import { PERMIT_TYPES, PermitType } from "../types/PermitType";
 import { MANDATORY_NRSCV_CONDITIONS, NRSCV_CONDITIONS } from "../constants/nrscv";
 import { MANDATORY_NRQCV_CONDITIONS, NRQCV_CONDITIONS } from "../constants/nrqcv";
+import { Nullable } from "../../../common/types/common";
+
+/**
+ * Determine whether or not a permit with given permit type can have LCV conditions attached to it.
+ * @param permitType Permit type
+ * @returns Whether or not a permit with given permit type can have LCV conditions attached to it
+ */
+export const canPermitTypeIncludeLCVCondition = (permitType?: Nullable<PermitType>) => {
+  if (!permitType) return false;
+  return ([
+    PERMIT_TYPES.TROS,
+    PERMIT_TYPES.STOS,
+  ] as PermitType[]).includes(permitType);
+};
 
 /**
  * Get mandatory conditions that must be selected for a permit type.
@@ -21,18 +35,22 @@ export const getMandatoryConditions = (
   permitType: PermitType,
   includeLcvCondition?: boolean,
 ) => {
-  const additionalConditions = includeLcvCondition ? [LCV_CONDITION] : [];
+  const additionalConditions =
+    includeLcvCondition && canPermitTypeIncludeLCVCondition(permitType)
+      ? [LCV_CONDITION]
+      : [];
+
   switch (permitType) {
     case PERMIT_TYPES.QRFR:
-      return MANDATORY_QRFR_CONDITIONS;
+      return MANDATORY_QRFR_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.STFR:
       return MANDATORY_STFR_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.NRSCV:
-      return MANDATORY_NRSCV_CONDITIONS;
+      return MANDATORY_NRSCV_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.NRQCV:
-      return MANDATORY_NRQCV_CONDITIONS;
+      return MANDATORY_NRQCV_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.MFP:
-      return MANDATORY_MFP_CONDITIONS; // MFP never allows additional conditions
+      return MANDATORY_MFP_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.STOS:
       return MANDATORY_STOS_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.TROW:
@@ -48,18 +66,22 @@ const getConditionsByPermitType = (
   permitType: PermitType,
   includeLcvCondition?: boolean,
 ) => {
-  const additionalConditions = includeLcvCondition ? [LCV_CONDITION] : [];
+  const additionalConditions =
+    includeLcvCondition && canPermitTypeIncludeLCVCondition(permitType)
+      ? [LCV_CONDITION]
+      : [];
+  
   switch (permitType) {
     case PERMIT_TYPES.QRFR:
-      return QRFR_CONDITIONS;
+      return QRFR_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.STFR:
       return STFR_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.NRSCV:
-      return NRSCV_CONDITIONS;
+      return NRSCV_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.NRQCV:
-      return NRQCV_CONDITIONS;
+      return NRQCV_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.MFP:
-      return MFP_CONDITIONS; // MFP never allows additional conditions
+      return MFP_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.STOS:
       return STOS_CONDITIONS.concat(additionalConditions);
     case PERMIT_TYPES.TROW:
@@ -120,12 +142,14 @@ export const getDefaultConditions = (
  * @param isLcvDesignated Whether or not the LCV designation is to be used
  * @param prevSelectedConditions Previously selected permit conditions
  * @param vehicleSubtype Selected vehicle subtype
+ * @param permitType Permit type
  * @returns Updated permit conditions
  */
 export const getUpdatedConditionsForLCV = (
   isLcvDesignated: boolean,
   prevSelectedConditions: PermitCondition[],
   vehicleSubtype: string,
+  permitType: PermitType,
 ) => {
   if (!isLcvDesignated) {
     // If LCV not designated, remove LCV condition
@@ -146,10 +170,11 @@ export const getUpdatedConditionsForLCV = (
   }
 
   // If LCV is designated, and vehicle subtype is LCV but conditions don't have LCV,
-  // then add that LCV condition
+  // then add that LCV condition if the permit type allows it
   if (
     isVehicleSubtypeLCV(vehicleSubtype)
     && !prevSelectedConditions.some(({ condition }) => condition === LCV_CONDITION.condition)
+    && canPermitTypeIncludeLCVCondition(permitType)
   ) {
     return sortConditions([...prevSelectedConditions, LCV_CONDITION]);
   }
@@ -181,6 +206,7 @@ export const getPermitConditionSelectionState = (
     isLcvDesignated,
     prevSelectedConditions,
     vehicleSubtype,
+    permitType,
   );
 
   return defaultConditionsForPermitType.map((defaultCondition) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Include LCV condition only for permit types that allow it, and excluded it for other permit types

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] When creating/editing/amending a TROS or STOS permit/application, verify that selecting an LCV vehicle subtype (or deselecting it) will automatically show the list of correctly selected permit conditions (with LCV condition attached when LCV vehicle subtype is selected, and not attached when no LCV subtype is selected)
- [x] When creating/editing/amending any permit type that is not a TROS or STOS permit/application, verify that selecting an LCV vehicle subtype (or deselecting it) will never attach the LCV condition to the list of selected permit conditions


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2040-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2040-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2040-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2040-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2040-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2040-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)