### PR TITLE
ORV2-4666-LOA section displayed on special authorization tab when there are no LOAs

### DIFF
--- a/frontend/src/features/settings/pages/SpecialAuthorizations/SpecialAuthorizations.tsx
+++ b/frontend/src/features/settings/pages/SpecialAuthorizations/SpecialAuthorizations.tsx
@@ -266,7 +266,7 @@ export const SpecialAuthorizations = ({ companyId }: { companyId: number }) => {
         />
       ) : null}
 
-      {canWriteLOA || (canReadLOA && activeLOAs.length > 0) ? (
+      {canWriteLOA || showActiveLOAsList || showExpiredLOAsLink ? (
         <div className="special-authorizations__loa">
           <div className="special-authorizations__section-header">
             <div className="special-authorizations__header-title">

--- a/frontend/src/features/settings/pages/SpecialAuthorizations/SpecialAuthorizations.tsx
+++ b/frontend/src/features/settings/pages/SpecialAuthorizations/SpecialAuthorizations.tsx
@@ -266,7 +266,7 @@ export const SpecialAuthorizations = ({ companyId }: { companyId: number }) => {
         />
       ) : null}
 
-      {canReadLOA ? (
+      {canWriteLOA || (canReadLOA && activeLOAs.length > 0) ? (
         <div className="special-authorizations__loa">
           <div className="special-authorizations__section-header">
             <div className="special-authorizations__header-title">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Added condition to only show LOA when there exists at least one or canWriteLOA permission.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Open as a staff that can write LOA and open that account simultaneously to see if there is any. The LOA section should not be displayed to CV client if there are not active LOAs.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2070-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2070-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2070-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2070-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2070-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2070-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2070-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2070-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2070-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2070-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2070-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2070-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)