### PR TITLE
ORV2-4703: Fix incorrect expiry date display on permit form after selected LOA for permit has been edited

### DIFF
--- a/frontend/src/features/permits/helpers/permitLOA.ts
+++ b/frontend/src/features/permits/helpers/permitLOA.ts
@@ -1,7 +1,7 @@
 import dayjs, { Dayjs } from "dayjs";
 
 import { LOADetail } from "../../settings/types/LOADetail";
-import { PermitType } from "../types/PermitType";
+import { isQuarterlyPermit, PermitType } from "../types/PermitType";
 import { getEndOfDate, getStartOfDate, toLocalDayjs } from "../../../common/helpers/formatDate";
 import { Nullable } from "../../../common/types/common";
 import { Application, ApplicationFormData } from "../types/application";
@@ -22,6 +22,7 @@ import { getUpdatedCLF } from "./conditionalLicensingFee/getUpdatedCLF";
 import { getAvailableCLFs } from "./conditionalLicensingFee/getAvailableCLFs";
 import { getVehicleWeightStatusForCLF } from "./vehicles/configuration/getVehicleWeightStatusForCLF";
 import { getUpdatedVehicleWeights } from "./vehicles/configuration/getUpdatedVehicleWeights";
+import { getExpiryDate } from "./permitState";
 
 /**
  * Filter valid LOAs for a given permit type.
@@ -255,6 +256,12 @@ export const applyUpToDateLOAsToApplication = <T extends Nullable<ApplicationFor
     durationOptions,
   );
 
+  const updatedExpiryDate = getExpiryDate(
+    applicationData.permitData.startDate,
+    isQuarterlyPermit(applicationData.permitType),
+    updatedDuration,
+  );
+
   // Update vehicle details in permit if selected LOAs changed
   const { updatedVehicle } = getUpdatedVehicleDetailsForLOAs(
     newSelectedLOAs,
@@ -297,6 +304,7 @@ export const applyUpToDateLOAsToApplication = <T extends Nullable<ApplicationFor
     permitData: {
       ...applicationData.permitData,
       permitDuration: updatedDuration,
+      expiryDate: updatedExpiryDate,
       loas: newSelectedLOAs,
       vehicleDetails: updatedVehicle,
       conditionalLicensingFee: updatedCLF,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Fix incorrect expiry date display on permit form after selected LOA for permit has been edited

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create an LOA without an expiry date, and proceed to create an application with that LOA and set the duration to 120 days. Once that application has been saved, go to update that same selected LOA by changing the LOA's expiry date from "Never expires" to some set expiry date (say slightly more than 2 months from the start date of the permit). Once this LOA is saved, go back to that previously created application, and notice that 1) this same LOA is still selected, and 2) the permit duration is automatically shortened from the previous 120 days to 60 days (assuming that the LOA expiry date was changed to a bit more than 2 months from the permit start date) and the only selectable durations are now 30 and 60 days, and that 3) the correct expiry date is now displayed on the form.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2072-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2072-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2072-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2072-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2072-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2072-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)