### PR TITLE
ORV2-4773: Prevent both staff and non-staff users from proceeding upon non-resident policy vehicle weight violations

### DIFF
--- a/frontend/src/features/permits/helpers/policy/shouldOverridePolicyViolations.ts
+++ b/frontend/src/features/permits/helpers/policy/shouldOverridePolicyViolations.ts
@@ -1,0 +1,35 @@
+import { PERMIT_TYPES, PermitType } from "../../types/PermitType";
+
+/**
+ * Determines whether or not permit policy violations can be overriden.
+ * @param violations Policy violations for a given permit
+ * @param isStaffUser Whether or not user is staff
+ * @param permitType Permit type
+ * @returns Whether or not policy violations should be overriden for a permit
+ */
+export const shouldOverridePolicyViolations = (
+  violations: {
+    [key: string]: string;
+  },
+  isStaffUser: boolean,
+  permitType: PermitType,
+) => {
+  const violationFieldReferences = Object.keys(violations);
+
+  // No violations would trivially override
+  if (violationFieldReferences.length === 0) return true;
+
+  // If isn't staff user, then policy violations should NOT be overriden
+  if (!isStaffUser) return false;
+
+  // For given permit type, check to see if policy violations should be overriden
+  if (permitType === PERMIT_TYPES.NRQCV || permitType === PERMIT_TYPES.NRSCV) {
+    // For non-resident permit types, if there are violations for either
+    // net weight or loaded GVW, those violations shouldn't be overriden (even for staff)
+    return !violationFieldReferences.includes("permitData.vehicleConfiguration.loadedGVW")
+      && !violationFieldReferences.includes("permitData.vehicleConfiguration.netWeight");
+  }
+  
+  // For all other scenarios, policy violations can be overriden for staff
+  return true;
+};

--- a/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
+++ b/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
@@ -57,6 +57,7 @@ import {
 import OnRouteBCContext from "../../../../../common/authentication/OnRouteBCContext";
 import { shouldOverridePolicyInvalidSubtype } from "../../../helpers/vehicles/subtypes/shouldOverridePolicyInvalidSubtype";
 import { useMemoizedArray } from "../../../../../common/hooks/useMemoizedArray";
+import { shouldOverridePolicyViolations } from "../../../helpers/policy/shouldOverridePolicyViolations";
 
 const FEATURE = ORBC_FORM_FEATURES.AMEND_PERMIT;
 
@@ -201,8 +202,11 @@ export const AmendPermitForm = () => {
   // When "Continue" button is clicked
   const onContinue = async (data: FieldValues) => {
     const updatedViolations = await triggerPolicyValidation();
-    // prevent CV client continuing if there are policy engine validation errors
-    if (Object.keys(updatedViolations).length > 0 && !isStaffUser) {
+
+    // If there are policy engine validation errors, form validation fails unless those violations
+    // can be overriden
+    if (!shouldOverridePolicyViolations(updatedViolations, isStaffUser, data.permitType)) {
+      console.error(updatedViolations);
       return;
     }
 

--- a/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
+++ b/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
@@ -61,6 +61,7 @@ import {
 import { useApplicationInQueueMetadata } from "../../../queue/hooks/hooks";
 import { UnavailableApplicationModal } from "../../../queue/components/UnavailableApplicationModal";
 import { shouldOverridePolicyInvalidSubtype } from "../../helpers/vehicles/subtypes/shouldOverridePolicyInvalidSubtype";
+import { shouldOverridePolicyViolations } from "../../helpers/policy/shouldOverridePolicyViolations";
 
 const FEATURE = ORBC_FORM_FEATURES.APPLICATION;
 
@@ -238,8 +239,10 @@ export const ApplicationForm = ({
   // When "Continue" button is clicked
   const onContinue = async (data: ApplicationFormData) => {
     const updatedViolations = await triggerPolicyValidation();
-    // prevent CV client continuing if there are policy engine validation errors
-    if (Object.keys(updatedViolations).length > 0 && !isStaffUser) {
+
+    // If there are policy engine validation errors, form validation fails unless those violations
+    // can be overriden
+    if (!shouldOverridePolicyViolations(updatedViolations, isStaffUser, data.permitType)) {
       console.error(updatedViolations);
       return;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Add helper to override permit policy violations when needed, add check for non-resident vehicle weight policy violations

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Login as staff, and create a new non-resident permit application, and enter an invalid large number for vehicle weight (either loaded GVW or net weight, depending on which conditional licensing fee type is selected). Observe that a policy violation will occur, and that the user cannot proceed to the review and confirm page upon trying to continue.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2101-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2101-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2101-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2101-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2101-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2101-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)