### PR TITLE
ORV2-4912 Remove Credit Account Mismatch handling from main

### DIFF
--- a/frontend/src/features/permits/apiManager/permitsAPI.ts
+++ b/frontend/src/features/permits/apiManager/permitsAPI.ts
@@ -27,7 +27,6 @@ import {
 import {
   CompleteTransactionRequestData,
   CompleteTransactionResponseData,
-  StartTransactionErrorData,
   StartTransactionRequestData,
   StartTransactionResponseData,
 } from "../types/payment";
@@ -318,7 +317,7 @@ export const downloadReceiptPdf = async (
 export const startTransaction = async (
   requestData: StartTransactionRequestData,
 ): Promise<
-  RequiredOrNull<StartTransactionResponseData | StartTransactionErrorData>
+  RequiredOrNull<StartTransactionResponseData>
 > => {
   try {
     const response = await httpPOSTRequest(

--- a/frontend/src/features/permits/apiManager/permitsAPI.ts
+++ b/frontend/src/features/permits/apiManager/permitsAPI.ts
@@ -326,25 +326,7 @@ export const startTransaction = async (
       replaceEmptyValuesWithNull(requestData),
     );
     if (response.status !== 201) {
-      if (response.status === 422) {
-        const { error } = response.data;
-        const { errorCode } = error as {
-          message: string;
-          additionalInfo: string;
-          errorCode: string;
-        };
-        // Credit Account mismatch has a unique error message to be displayed
-        // and hence the component needs to know about it.
-        if (errorCode === "CREDIT_ACCOUNT_MISMATCH") {
-          return {
-            errorCode,
-          };
-        } else {
-          return null;
-        }
-      } else {
-        return null;
-      }
+      return null;
     }
     return response.data as StartTransactionResponseData;
   } catch (err) {

--- a/frontend/src/features/permits/hooks/hooks.ts
+++ b/frontend/src/features/permits/hooks/hooks.ts
@@ -10,10 +10,7 @@ import {
 } from "@tanstack/react-query";
 
 import { IssuePermitsResponse } from "../types/permit";
-import {
-  StartTransactionErrorData,
-  StartTransactionResponseData,
-} from "../types/payment";
+import { StartTransactionResponseData } from "../types/payment";
 import { isPermitTypeValid } from "../types/PermitType";
 import { isPermitIdNumeric } from "../helpers/permitState";
 import { deserializeApplicationResponse } from "../helpers/serialize/deserializeApplication";
@@ -223,27 +220,18 @@ export const usePermitDetailsQuery = (
  */
 export const useStartTransaction = () => {
   const [transaction, setTransaction] =
-    useState<
-      Nullable<StartTransactionResponseData | StartTransactionErrorData>
-    >(undefined);
+    useState<Nullable<StartTransactionResponseData>>(undefined);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const mutation = useMutation({
     mutationFn: startTransaction,
     retry: false,
     onSuccess: (transactionData) => {
-      // If there are no errors from the API response body,
-      // set the transaction data and invalidate the transaction query.
-      if (!(transactionData as StartTransactionErrorData)?.errorCode) {
-        queryClient.invalidateQueries({
-          queryKey: ["transaction"],
-        });
-        queryClient.setQueryData(["transaction"], transactionData);
-        setTransaction(transactionData as StartTransactionResponseData);
-      } else {
-        // Set errorCode in the object to indicate there was an error.
-        setTransaction(transactionData as StartTransactionErrorData);
-      }
+      queryClient.invalidateQueries({
+        queryKey: ["transaction"],
+      });
+      queryClient.setQueryData(["transaction"], transactionData);
+      setTransaction(transactionData as StartTransactionResponseData);
     },
     onError: (error: AxiosError) => {
       console.error(error);

--- a/frontend/src/features/permits/pages/ShoppingCart/ShoppingCartPage.tsx
+++ b/frontend/src/features/permits/pages/ShoppingCart/ShoppingCartPage.tsx
@@ -9,7 +9,6 @@ import { PermitPayFeeSummary } from "../Application/components/pay/PermitPayFeeS
 import OnRouteBCContext from "../../../../common/authentication/OnRouteBCContext";
 import { useIssuePermits, useStartTransaction } from "../../hooks/hooks";
 import {
-  StartTransactionErrorData,
   StartTransactionResponseData,
   TRANSACTION_TYPES,
 } from "../../types/payment";
@@ -194,10 +193,7 @@ export const ShoppingCartPage = () => {
     // transaction is undefined when payment endpoint has not been requested
     // ie. "Pay Now" button has not been pressed
     if (typeof transaction !== "undefined") {
-      if (
-        !transaction ||
-        (transaction as StartTransactionErrorData)?.errorCode
-      ) {
+      if (!transaction) {
         // Payment failed - ie. transaction object is null
         navigate(SHOPPING_CART_ROUTES.DETAILS(true));
       } else if (
@@ -497,15 +493,7 @@ export const ShoppingCartPage = () => {
             />
           ) : null}
 
-          {paymentFailed ? (
-            <PaymentFailedBanner
-              errorMessage={
-                (transaction as StartTransactionErrorData)?.errorCode
-                  ? "Credit Account mismatch. One or more of the selected items uses a different credit account from the currently active one."
-                  : ""
-              }
-            />
-          ) : null}
+          {paymentFailed ? <PaymentFailedBanner /> : null}
 
           <PermitPayFeeSummary
             calculatedFee={selectedTotalFee}

--- a/frontend/src/features/permits/types/payment.ts
+++ b/frontend/src/features/permits/types/payment.ts
@@ -88,10 +88,6 @@ export interface StartTransactionResponseData
   url?: string;
 }
 
-export interface StartTransactionErrorData {
-  errorCode: string;
-}
-
 export type CompleteTransactionRequestData = NullableFields<PaymentGatewayData>;
 
 export interface CompleteTransactionResponseData


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Removes the credit account mismatch handling from `main`  because the `frcr` branch merge is imminent, where the error handling of `startTransaction` is differently implemented. #2166 has already been merged into `frcr` to align with the new implementation and will make it to `main` whenever `frcr` is merged. 




---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2167-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2167-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2167-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2167-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2167-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2167-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)