### PR TITLE
ORV2-5102: Hot Fix for zero dollar amount amendment failure

### DIFF
--- a/vehicles/src/common/helper/permit-fee.helper.ts
+++ b/vehicles/src/common/helper/permit-fee.helper.ts
@@ -16,6 +16,7 @@ import {
 import { differenceBetween } from './date-time.helper';
 import * as dayjs from 'dayjs';
 import { Nullable } from '../types/common';
+import { PaymentMethodType } from '../enum/payment-method-type.enum';
 
 /**
  * Calculates the permit fee based on the application and old amount.
@@ -153,6 +154,25 @@ export const currentPermitFee = (
   return oldAmount > 0
     ? pricePerTerm * permitTerms - oldAmount
     : pricePerTerm * permitTerms + oldAmount;
+};
+
+/**
+ * Determines whether or not transaction is valid based on payment method and if it's approved.
+ * @param paymentMethod Payment method used
+ * @param transactionApproved Approval status of the transaction
+ * @returns Whether or not the transaction is valid
+ */
+export const isValidTransaction = (
+  paymentMethod: PaymentMethodType,
+  transactionApproved?: Nullable<number>,
+) => {
+  // For payment methods using payment gateways (ie. PayBC), a payment is considered to have succeeded only if its
+  // pgApproved flag is 1, and transactions using all other payment methods (ie. IcePay) is automatically considered
+  // to have succeeded
+  return (
+    paymentMethod !== PaymentMethodType.WEB ||
+    (Boolean(transactionApproved) && transactionApproved > 0)
+  );
 };
 
 export const calculatePermitAmount = (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

It is possible that a user tries to pay for an application multiple times (possibly failing initially, and succeeding later on) using PayBC. The expectation is that when it comes to calculating how much was paid for a permit, these payments that failed should not be considered (only the ones that succeeded should). However, a bug exists in the backend in which these failed payment amounts were still included, and ended calculating incorrect amounts for this scenario, resulting in an amount mismatch failure when user tries to amend a permit.

Now, this fix is applied to the backend, so that invalid/failed payments will no longer be counted when performing cost calculation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] As a CV client, create a TROS application with any duration, and added to cart and proceed to pay for it using PayBC. Upon arrival on the PayBC payment gateway, enter invalid CVC or expiry date for the card to make sure that the transaction fails. Heading back to the shopping cart, try to pay for the application again, this time entering correct card information. Once the application has been issued, log in as staff to amend this issued permit by changing the vehicle plate or VIN (or anything that doesn't incur cost, ie. don't edit the duration). Proceed with continuing all the way to the Amend Finish page (with the refund info), and upon clicking Finish, the amendment should be successful.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
