### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/dops/Dockerfile
+++ b/dops/Dockerfile
@@ -14,7 +14,7 @@ ENV PUPPETEER_SKIP_CHROME_DOWNLOAD=true
 ENV PUPPETEER_SKIP_CHROME_HEADLESS_SHELL_DOWNLOAD=true
 
 # Install packages, build and keep only prod packages
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN npm run build
 RUN npm prune --production
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ COPY ./package*.json ./
 RUN mkdir /.npm && chmod 777 /.npm
 
 # Install dependencies (npm ci makes sure the exact versions in the lockfile gets installed)
-RUN npm ci
+RUN npm ci --ignore-scripts
 
 # Copy app files
 COPY . .

--- a/policy/Dockerfile
+++ b/policy/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 RUN mkdir /.npm && chmod 777 /.npm
 
 # Install packages, build and keep only prod packages
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN npm run build
 RUN npm prune --production
 

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 RUN mkdir /.npm && chmod 777 /.npm
 
 # Install packages, build and keep only prod packages
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN npm run build
 RUN npm prune --production
 

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 RUN mkdir /.npm && chmod 777 /.npm
 
 # Install packages, build and keep only prod packages
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN npm run build
 RUN npm prune --production
 

--- a/vehicles/Dockerfile
+++ b/vehicles/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 RUN mkdir /.npm && chmod 777 /.npm
 
 # Install packages, build and keep only prod packages
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN npm run build
 RUN npm prune --production
 


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2198-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2198-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2198-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2198-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2198-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2198-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)