### PR TITLE
Hotfix: Allow users to proceed to refund page when amending permit if refund amount is zero

### DIFF
--- a/frontend/src/features/permits/pages/Amend/components/AmendPermitReview.tsx
+++ b/frontend/src/features/permits/pages/Amend/components/AmendPermitReview.tsx
@@ -38,6 +38,7 @@ import { isAxiosError } from "axios";
 import { PERMIT_ACTION_ORIGINS } from "../../../../idir/search/types/types";
 import { usePermissionMatrix } from "../../../../../common/authentication/PermissionMatrix";
 import { AuthorizationRequiredModal } from "./modal/AuthorizationRequiredModal";
+import { isZeroAmount } from "../../../helpers/feeSummary";
 
 export const AmendPermitReview = () => {
   const navigate = useNavigate();
@@ -133,7 +134,8 @@ export const AmendPermitReview = () => {
     if (savedApplication) {
       setAmendmentApplication(savedApplication);
 
-      if (canProcessAmendmentRefund) {
+      // Allow user to proceed to refund if user has permissions, or if refund amount is zero
+      if (canProcessAmendmentRefund || isZeroAmount(amountToRefund)) {
         next();
       } else {
         setShowAuthorizationRequiredModal(true);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

- Fixes problem where users are not able to refund a permit during amendment when the refund amount is $0.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create a TROS or TROW permit. Login as a PPC clerk staff, and attempt to amend the permit by changing vehicle plate or make (basically anything that doesn't incur an additional refund amount). Observe that the refund amount is $0 on the amend review page, and that after selecting the attestation checkboxes and clicking on Continue, the PPC clerk user is able to proceed to the refund page and complete the amendment.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2200-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2200-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2200-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2200-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2200-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2200-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)