### PR TITLE
ORV2-5025: Filter out trailer subtypes and vehicles from frontend side for STOS permit type

### DIFF
--- a/frontend/src/features/permits/helpers/vehicles/subtypes/getEligibleVehicleSubtypes.ts
+++ b/frontend/src/features/permits/helpers/vehicles/subtypes/getEligibleVehicleSubtypes.ts
@@ -1,7 +1,7 @@
 import { Policy } from "onroute-policy-engine";
 
 import { Nullable } from "../../../../../common/types/common";
-import { PermitType } from "../../../types/PermitType";
+import { isTermPermitType, PermitType } from "../../../types/PermitType";
 import { getDefaultRequiredVal } from "../../../../../common/helpers/util";
 import { DEFAULT_EMPTY_SELECT_VALUE } from "../../../../../common/constants/constants";
 
@@ -38,7 +38,10 @@ export const getEligibleVehicleSubtypes = (
       ).keys(),
       ...getDefaultRequiredVal(
         new Map<string, string>(),
-        subtypesMap.get("trailers"),
+        // Only term permits allow trailer subtypes to be used
+        isTermPermitType(permitType)
+          ? subtypesMap.get("trailers")
+          : undefined,
       ).keys(),
     ],
   );

--- a/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/VehicleDetails.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/VehicleDetails.tsx
@@ -91,6 +91,7 @@ export const VehicleDetails = ({
       PERMIT_TYPES.QRFR,
       PERMIT_TYPES.NRSCV,
       PERMIT_TYPES.NRQCV,
+      PERMIT_TYPES.STOS,
     ] as PermitType[]
   ).includes(permitType);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Filter out trailer subtypes and vehicles from frontend dropdown selection for STOS permit type (does not affect the trailer selection after power units have been selected though)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create a trailer vehicle in vehicle inventory with a trailer subtype that is known to be applicable for a given commodity (eg. Conveyor), and then create a new/existing STOS application, and when adding a power unit, observe that no trailers should appear as a selectable option when clicking on the vehicle inventory dropdown.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2215-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2215-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2215-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2215-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2215-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2215-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)