### PR TITLE
ORV2-5060: Frontend enhancement on permit review/confirm page for return trip

### DIFF
--- a/frontend/src/features/permits/pages/Application/components/review/PermitReview.tsx
+++ b/frontend/src/features/permits/pages/Application/components/review/PermitReview.tsx
@@ -201,6 +201,7 @@ export const PermitReview = (props: PermitReviewProps) => {
           routeDetails={props.route}
           oldRouteDetails={props.oldFields?.permitData?.permittedRoute}
           showChangedFields={props.showChangedFields}
+          permitType={props.permitType}
         />
 
         <ThirdPartyLiabilitySection

--- a/frontend/src/features/permits/pages/Application/components/review/TripDetails.scss
+++ b/frontend/src/features/permits/pages/Application/components/review/TripDetails.scss
@@ -46,6 +46,11 @@
         }
       }
 
+      &__radio-group {
+        display: flex;
+        flex-direction: row;
+      }
+
       &__info {
         display: flex;
         flex-direction: row;

--- a/frontend/src/features/permits/pages/Application/components/review/TripDetails.tsx
+++ b/frontend/src/features/permits/pages/Application/components/review/TripDetails.tsx
@@ -6,14 +6,17 @@ import { DiffChip } from "./DiffChip";
 import { PermittedRoute } from "../../../../types/PermittedRoute";
 import { getDefaultRequiredVal } from "../../../../../../common/helpers/util";
 import { areOrderedSequencesEqual, areValuesDifferent } from "../../../../../../common/helpers/equality";
+import { PERMIT_TYPES, PermitType } from "../../../../types/PermitType";
 
 export const TripDetails = ({
   routeDetails,
   oldRouteDetails,
+  permitType,
   showChangedFields = false,
 }: {
   routeDetails?: Nullable<PermittedRoute>;
   oldRouteDetails?: Nullable<PermittedRoute>;
+  permitType?: Nullable<PermitType>;
   showChangedFields?: boolean;
 }) => {
   const origin = getDefaultRequiredVal("", routeDetails?.manualRoute?.origin);
@@ -70,6 +73,12 @@ export const TripDetails = ({
     return show ? <DiffChip /> : null;
   };
 
+  const showReturnTrip = permitType && ([
+    PERMIT_TYPES.STOS,
+    PERMIT_TYPES.STOW,
+    PERMIT_TYPES.STWS,
+  ] as PermitType[]).includes(permitType);
+
   return routeDetails ? (
     <Box className="review-trip-details">
       <Box className="review-trip-details__header">
@@ -115,7 +124,7 @@ export const TripDetails = ({
               </div>
             ) : null}
 
-            {isReturnTrip ? (
+            {showReturnTrip ? (
               <div className="manual-route__is-return-trip">
                 <RadioGroup
                   className="manual-route__radio-group"
@@ -129,7 +138,7 @@ export const TripDetails = ({
                       disabled: "return-trip-option--disabled",
                       label: "return-trip-option__label",
                     }}
-                    label="Return Trip"
+                    label={isReturnTrip ? "Return Trip" : "One Way"}
                     value={isReturnTrip}
                     control={
                       <Radio
@@ -137,15 +146,19 @@ export const TripDetails = ({
                         className="return-trip-option__radio return-trip-option__radio--disabled"
                       />}
                   />
+
+                  {showDiffChip(!isReturnTrip && changedFields.isReturnTrip)}
                 </RadioGroup>
 
-                <Typography className="manual-route__info">
-                  <span className="manual-route__info-text">
-                    Permitted for return trip along the same route.
-                  </span>
+                {isReturnTrip ? (
+                  <Typography className="manual-route__info">
+                    <span className="manual-route__info-text">
+                      Permitted for return trip along the same route.
+                    </span>
 
-                  {showDiffChip(changedFields.isReturnTrip)}
-                </Typography>
+                    {showDiffChip(changedFields.isReturnTrip)}
+                  </Typography>
+                ) : null}
               </div>
             ) : null}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

- Always show return trip status (both "One Way" and "Return Trip") on review and confirm page for applicable permit types

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Create a STOS application/permit, and set the return trip flag to "One Way". Observe that after continuing to the review/confirm page, the return trip section will now show "One Way".

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2223-frontend.apps.silver.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2223-vehicles.apps.silver.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2223-dops.apps.silver.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2223-policy.apps.silver.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2223-scheduler.apps.silver.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2223-public.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)