### PR TITLE
ORV2-5470 - FE: STOS loaded dimensions not removed when removing power unit

### DIFF
--- a/frontend/src/features/permits/pages/Application/components/form/PermitForm.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/PermitForm.tsx
@@ -176,6 +176,7 @@ export const PermitForm = () => {
           onSetVehicle={onSetVehicle}
           onClearVehicle={onClearVehicle}
           onUpdateVehicleConfigTrailers={onUpdateVehicleConfigTrailers}
+          onUpdateVehicleConfig={onUpdateVehicleConfig}
         />
 
         <LoadedDimensionsSection

--- a/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/VehicleInformationSection.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/VehicleInformationSection/VehicleInformationSection.tsx
@@ -17,10 +17,16 @@ import { VehicleDetails } from "./VehicleDetails";
 import { PowerUnitInfo } from "./PowerUnitInfo";
 import { PowerUnitDialog } from "./PowerUnitDialog";
 import { AddTrailer } from "./AddTrailer";
-import { VehicleInConfiguration } from "../../../../../types/PermitVehicleConfiguration";
+import {
+  PermitVehicleConfiguration,
+  VehicleInConfiguration,
+} from "../../../../../types/PermitVehicleConfiguration";
 import { requiredPowerUnit } from "../../../../../../../common/helpers/validationMessages";
 import { ApplicationFormData } from "../../../../../types/application";
-import { Nullable, ORBCFormFeatureType } from "../../../../../../../common/types/common";
+import {
+  Nullable,
+  ORBCFormFeatureType,
+} from "../../../../../../../common/types/common";
 import { DEFAULT_EMPTY_SELECT_VALUE } from "../../../../../../../common/constants/constants";
 
 export const VehicleInformationSection = ({
@@ -40,6 +46,7 @@ export const VehicleInformationSection = ({
   onSetVehicle,
   onClearVehicle,
   onUpdateVehicleConfigTrailers,
+  onUpdateVehicleConfig,
 }: {
   permitType: PermitType;
   feature: ORBCFormFeatureType;
@@ -62,6 +69,7 @@ export const VehicleInformationSection = ({
   onUpdateVehicleConfigTrailers: (
     updatedTrailerSubtypes: VehicleInConfiguration[],
   ) => void;
+  onUpdateVehicleConfig: (vehicleConfig: PermitVehicleConfiguration) => void;
 }) => {
   const isSingleTrip = permitType === PERMIT_TYPES.STOS;
   const infoSectionClassName =
@@ -73,7 +81,8 @@ export const VehicleInformationSection = ({
     `${isSingleTrip ? " vehicle-information-section__info-banner--single-trip" : ""}`;
 
   const isCommodityTypeSelected =
-    Boolean(selectedCommodityType) && (selectedCommodityType !== DEFAULT_EMPTY_SELECT_VALUE);
+    Boolean(selectedCommodityType) &&
+    selectedCommodityType !== DEFAULT_EMPTY_SELECT_VALUE;
 
   const isPowerUnitSelectedForSingleTrip =
     isSingleTrip && Boolean(vehicleFormData.vin);
@@ -97,6 +106,7 @@ export const VehicleInformationSection = ({
   const handleRemovePowerUnit = () => {
     onClearVehicle(false);
     onUpdateVehicleConfigTrailers([]);
+    onUpdateVehicleConfig({});
   };
 
   const handleClosePowerUnitDialog = () => {
@@ -152,7 +162,10 @@ export const VehicleInformationSection = ({
                     aria-label="Add Power Unit"
                     variant="contained"
                     color="tertiary"
-                    disabled={isPowerUnitSelectedForSingleTrip || !isCommodityTypeSelected}
+                    disabled={
+                      isPowerUnitSelectedForSingleTrip ||
+                      !isCommodityTypeSelected
+                    }
                     onClick={handleClickAddPowerUnit}
                   >
                     <FontAwesomeIcon


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Clears vehicle configuration when removing power unit

Fixes [#ORV2-5470](https://moti-imb.atlassian.net/browse/ORV2-5470?atlOrigin=eyJpIjoiZjM5OTMyZDI2ZGE3NGZlOGIzMWMyMmU3YTBlOGNjOTEiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2265-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2265-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2265-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2265-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2265-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2265-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)