### PR TITLE
ORV2-5350 - FE: Enable STOW evaluation for Drive/Jeep axle unit load equalization.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "material-react-table": "^2.13.3",
     "mui-nested-menu": "^3.4.0",
     "oidc-client-ts": "^3.1.0",
-    "onroute-policy-engine": "^2.9.0",
+    "onroute-policy-engine": "^2.12.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.test.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { PERMIT_TYPES } from "../../../../../../types/PermitType";
+import { AxleConfiguration, AxleUnit } from "../../../../../../types/AxleUnit";
+import { POLICY_CHECK_ID_TYPES } from "../../../../../../types/AxleCalculationResult";
+import { AxleSpacingAndWeightsTable } from "./AxleSpacingAndWeightsTable";
+
+const loadEqualizationMessage =
+  "Axle Unit 2 and Axle Unit 3 must be load equalized within 1000 kg.";
+
+const powerUnitAxleConfiguration: AxleUnit[] = [
+  {
+    numberOfAxles: 1,
+    axleUnitWeight: 6700,
+    numberOfTires: 2,
+    tireSize: 355,
+  },
+  {
+    interaxleSpacing: 3.5,
+  },
+  {
+    numberOfAxles: 2,
+    axleSpread: 1.6,
+    axleUnitWeight: 12000,
+    numberOfTires: 4,
+    tireSize: 330,
+  },
+];
+
+const jeepAxleConfiguration: AxleUnit[] = [
+  {
+    interaxleSpacing: 3,
+  },
+  {
+    numberOfAxles: 2,
+    axleSpread: 1.6,
+    axleUnitWeight: 10999,
+    numberOfTires: 4,
+    tireSize: 330,
+  },
+];
+
+const combinedAxleConfiguration: AxleConfiguration[] = [
+  {
+    numberOfAxles: 1,
+    axleUnitWeight: 6700,
+    numberOfTires: 2,
+    tireSize: 355,
+  },
+  {
+    numberOfAxles: 2,
+    axleSpread: 1.6,
+    interaxleSpacing: 3.5,
+    axleUnitWeight: 12000,
+    numberOfTires: 4,
+    tireSize: 330,
+  },
+  {
+    numberOfAxles: 2,
+    axleSpread: 1.6,
+    interaxleSpacing: 3,
+    axleUnitWeight: 10999,
+    numberOfTires: 4,
+    tireSize: 330,
+  },
+];
+
+describe("AxleSpacingAndWeightsTable", () => {
+  it("displays and highlights a drive and jeep load equalization failure", async () => {
+    const user = userEvent.setup();
+    const runAxleCalculation = vi.fn().mockReturnValue({
+      results: [
+        {
+          id: POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION,
+          result: "fail",
+          message: loadEqualizationMessage,
+          startAxleUnit: 2,
+          endAxleUnit: 3,
+        },
+      ],
+      totalOverload: 0,
+    });
+
+    render(
+      <AxleSpacingAndWeightsTable
+        permitType={PERMIT_TYPES.STOW}
+        powerUnitSubtypeNamesMap={new Map([["TRKTRAC", "Truck Tractor"]])}
+        vehicleFormData={{
+          vehicleId: "101",
+          vin: "654321",
+          plate: "D654321",
+          make: "Custom",
+          year: 2010,
+          countryCode: "CA",
+          provinceCode: "BC",
+          vehicleType: "powerUnit",
+          vehicleSubType: "TRKTRAC",
+          licensedGVW: 40000,
+        }}
+        trailerSubtypeNamesMap={new Map([["JEEPSRG", "Jeep"]])}
+        vehicleConfiguration={{
+          axleConfiguration: powerUnitAxleConfiguration,
+          trailers: [
+            {
+              vehicleSubType: "JEEPSRG",
+              axleConfiguration: jeepAxleConfiguration,
+            },
+          ],
+        }}
+        tireSizeOptions={[
+          { name: "330", size: 330 },
+          { name: "355", size: 355 },
+        ]}
+        runAxleCalculation={runAxleCalculation}
+        combineAxleConfigurations={() => combinedAxleConfiguration}
+        calculateGCVW={() => 29699}
+        onUpdatePowerUnitAxleConfiguration={vi.fn()}
+        onUpdateTrailerAxleConfiguration={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Calculate" }));
+
+    expect(await screen.findByText(loadEqualizationMessage)).toHaveClass(
+      "results__text--fail",
+    );
+    expect(
+      screen.queryByText("This permit type is not required."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("You may require a different permit type"),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByDisplayValue("6700").closest(".table__input"),
+    ).not.toHaveClass("table__input--fail");
+    expect(
+      screen.getByDisplayValue("12000").closest(".table__input"),
+    ).toHaveClass("table__input--fail");
+    expect(
+      screen.getByDisplayValue("10999").closest(".table__input"),
+    ).toHaveClass("table__input--fail");
+  });
+});

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.tsx
@@ -131,6 +131,7 @@ export const AxleSpacingAndWeightsTable = ({
   // Since we are not yet handling all evaluations returned from the policyEngine.runAxleCalculation(), this set allows us to filter the results to only those we have implemented.
   const DISPLAYABLE_POLICY_CHECK_IDS = new Set<PolicyCheckIdType>([
     POLICY_CHECK_ID_TYPES.BRIDGE_FORMULA,
+    POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION,
     POLICY_CHECK_ID_TYPES.NUMBER_OF_AXLES,
   ]);
 
@@ -302,6 +303,11 @@ export const AxleSpacingAndWeightsTable = ({
 
         case POLICY_CHECK_ID_TYPES.BRIDGE_FORMULA:
           return [POLICY_CHECK_ID_TYPES.BRIDGE_FORMULA];
+
+        case POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION:
+          return rowType === ASW_TABLE_ROW_TYPES.AXLE
+            ? [POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION]
+            : [];
 
         default:
           return [];

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.tsx
@@ -308,6 +308,8 @@ export const AxleSpacingAndWeightsTable = ({
         case POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION:
           return rowType === ASW_TABLE_ROW_TYPES.AXLE
             ? [POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION]
+            : [];
+
         case POLICY_CHECK_ID_TYPES.NUMBER_OF_WHEELS_PER_AXLE:
           return rowType === ASW_TABLE_ROW_TYPES.AXLE
             ? [POLICY_CHECK_ID_TYPES.NUMBER_OF_WHEELS_PER_AXLE]

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleUnitRow.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleUnitRow.tsx
@@ -284,7 +284,13 @@ export const AxleUnitRow = ({
                 <NumberInput
                   classes={{ root: "table__input-container" }}
                   inputProps={{
-                    className: "table__input",
+                    className: `table__input ${
+                      axleCalculationFailure[
+                        POLICY_CHECK_ID_TYPES.DRIVE_JEEP_LOAD_EQUALIZATION
+                      ]
+                        ? "table__input--fail"
+                        : ""
+                    }`,
                     value: getDefaultRequiredVal(
                       null,
                       axleUnit?.axleUnitWeight,

--- a/frontend/src/features/permits/types/AxleCalculationResult.ts
+++ b/frontend/src/features/permits/types/AxleCalculationResult.ts
@@ -10,6 +10,7 @@ export const POLICY_CHECK_ID_TYPES = {
   BOOSTER_AXLE_LIMIT: "booster-axle-limit",
   BRIDGE_FORMULA: "bridge-formula",
   CHECK_PERMITTABLE_WEIGHT: "check-permittable-weight",
+  DRIVE_JEEP_LOAD_EQUALIZATION: "drive-jeep-load-equalization",
   MAX_TIRE_LOAD: "max-tire-load",
   MINIMUM_DRIVE_AXLE_WEIGHT: "minimum-drive-axle-weight",
   MINIMUM_STEER_AXLE_WEIGHT: "minimum-steer-axle-weight",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -42,6 +42,9 @@ export default defineConfig({
       exclude: ["node_modules/", "src/setupTests.ts"],
     },
   },
+  resolve: {
+    preserveSymlinks: true,
+  },
   build: {
     emptyOutDir: true,
     outDir: "build",

--- a/vehicles/package-lock.json
+++ b/vehicles/package-lock.json
@@ -41,7 +41,7 @@
         "nest-winston": "^1.10.2",
         "nestjs-cls": "^6.2.0",
         "nestjs-typeorm-paginate": "^4.1.0",
-        "onroute-policy-engine": "^2.11.0",
+        "onroute-policy-engine": "^2.12.0",
         "opossum": "^9.0.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -10461,9 +10461,9 @@
       }
     },
     "node_modules/onroute-policy-engine": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-2.11.0.tgz",
-      "integrity": "sha512-hx1pTmN26CTsvHsVlW2TyW/U0EhDPCxqXkEkmuCWgKfLWTAj7+PeMBol/J2rlFjMs+nu6w+coTGsYtYLFd+/AQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-2.12.1.tgz",
+      "integrity": "sha512-jgoQQUcJ5JJouP2wTR8IzFg6uu2OpndGbIe97w5DwHiv+9G1KlR6+dR1bZTmVGvQxUzGnvvtzhvyxWFq58S+Qg==",
       "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.11.13",

--- a/vehicles/package.json
+++ b/vehicles/package.json
@@ -73,7 +73,7 @@
     "nest-winston": "^1.10.2",
     "nestjs-cls": "^6.2.0",
     "nestjs-typeorm-paginate": "^4.1.0",
-    "onroute-policy-engine": "^2.9.0",
+    "onroute-policy-engine": "^2.12.0",
     "opossum": "^9.0.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",


### PR DESCRIPTION
This PR is ready for review. While strictly speaking we don't need to modify package.json version as we are using `^2.9.0` which would automatically pull in the latest, we have updated it for clarity's sake. For this PR to work, we need `2.12.0` to be pulled.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2291-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2291-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2291-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2291-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2291-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2291-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)