### PR TITLE
feat: ORV2-5456 - Enable 50% rule

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "material-react-table": "^2.13.3",
         "mui-nested-menu": "^3.4.0",
         "oidc-client-ts": "^3.1.0",
-        "onroute-policy-engine": "^2.15.0",
+        "onroute-policy-engine": "^2.16.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-error-boundary": "^4.1.2",
@@ -7812,9 +7812,9 @@
       }
     },
     "node_modules/onroute-policy-engine": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-2.15.0.tgz",
-      "integrity": "sha512-Vk7FMDPJWST2/C0mRxybiH+Xhx1plzFM2lPE+OSgD2scwp72VpY6+/g3FEUFtE5BPbcjMOscX8QvX66qDlzvjg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-2.16.0.tgz",
+      "integrity": "sha512-S7ozqB0I1RfLmyrrv/4kPuQvJjLCSs8CBOpa4lIOga3euvR6hQJ17EX5/9y97noq0ZXSG3e0Jrxyg/Kf25pUIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "dayjs": "^1.11.13",
@@ -15193,9 +15193,9 @@
       }
     },
     "onroute-policy-engine": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-2.15.0.tgz",
-      "integrity": "sha512-Vk7FMDPJWST2/C0mRxybiH+Xhx1plzFM2lPE+OSgD2scwp72VpY6+/g3FEUFtE5BPbcjMOscX8QvX66qDlzvjg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/onroute-policy-engine/-/onroute-policy-engine-2.16.0.tgz",
+      "integrity": "sha512-S7ozqB0I1RfLmyrrv/4kPuQvJjLCSs8CBOpa4lIOga3euvR6hQJ17EX5/9y97noq0ZXSG3e0Jrxyg/Kf25pUIg==",
       "requires": {
         "dayjs": "^1.11.13",
         "json-rules-engine": "^7.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "material-react-table": "^2.13.3",
     "mui-nested-menu": "^3.4.0",
     "oidc-client-ts": "^3.1.0",
-    "onroute-policy-engine": "^2.15.0",
+    "onroute-policy-engine": "^2.16.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.test.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.test.tsx
@@ -12,6 +12,8 @@ const singleSteerWeightMessage =
   "Single steer axle must be a minimum of 27% of tridem drive axle weight";
 const tandemSteerWeightMessage =
   "Tandem steer axle must be a minimum of 40% of drive axle weight";
+const pickerTruckTractorWeightMessage =
+  "Axle Unit 1 must carry a minimum 50% of Axle Unit 2 axle unit weight.";
 
 const powerUnitAxleConfiguration: AxleUnit[] = [
   {
@@ -211,6 +213,69 @@ describe("AxleSpacingAndWeightsTable", () => {
       "results__text--fail",
     );
 
+    expect(
+      screen.getByDisplayValue("6700").closest(".table__input"),
+    ).toHaveClass("table__input--fail");
+    expect(
+      screen.getByDisplayValue("12000").closest(".table__input"),
+    ).toHaveClass("table__input--fail");
+  });
+
+  it("displays and highlights picker truck tractor weight restriction failures", async () => {
+    const user = userEvent.setup();
+    const runAxleCalculation = vi.fn().mockReturnValue({
+      results: [
+        {
+          id: POLICY_CHECK_ID_TYPES.PICKER_TRUCK_TRACTOR_WEIGHT_RESTRICTIONS,
+          result: "fail",
+          message: pickerTruckTractorWeightMessage,
+          startAxleUnit: 1,
+          endAxleUnit: 2,
+        },
+      ],
+      totalOverload: 0,
+    });
+
+    render(
+      <AxleSpacingAndWeightsTable
+        permitType={PERMIT_TYPES.STOW}
+        powerUnitSubtypeNamesMap={new Map([
+          ["PICKRTT", "Picker Truck Tractor"],
+        ])}
+        vehicleFormData={{
+          vehicleId: "101",
+          vin: "654321",
+          plate: "D654321",
+          make: "Custom",
+          year: 2010,
+          countryCode: "CA",
+          provinceCode: "BC",
+          vehicleType: "powerUnit",
+          vehicleSubType: "PICKRTT",
+          licensedGVW: 40000,
+        }}
+        trailerSubtypeNamesMap={new Map()}
+        vehicleConfiguration={{
+          axleConfiguration: powerUnitAxleConfiguration,
+          trailers: [],
+        }}
+        tireSizeOptions={[
+          { name: "330", size: 330 },
+          { name: "355", size: 355 },
+        ]}
+        runAxleCalculation={runAxleCalculation}
+        combineAxleConfigurations={() => combinedAxleConfiguration.slice(0, 2)}
+        calculateGCVW={() => 18700}
+        onUpdatePowerUnitAxleConfiguration={vi.fn()}
+        onUpdateTrailerAxleConfiguration={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Calculate" }));
+
+    expect(
+      await screen.findByText(pickerTruckTractorWeightMessage),
+    ).toHaveClass("results__text--fail");
     expect(
       screen.getByDisplayValue("6700").closest(".table__input"),
     ).toHaveClass("table__input--fail");

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleSpacingAndWeightsTable.tsx
@@ -137,6 +137,7 @@ export const AxleSpacingAndWeightsTable = ({
     POLICY_CHECK_ID_TYPES.NUMBER_OF_AXLES,
     POLICY_CHECK_ID_TYPES.NUMBER_OF_WHEELS_PER_AXLE,
     POLICY_CHECK_ID_TYPES.MAX_TIRE_LOAD,
+    POLICY_CHECK_ID_TYPES.PICKER_TRUCK_TRACTOR_WEIGHT_RESTRICTIONS,
   ]);
 
   const failedAxleCalculationResults = axleCalculationResults?.results.filter(
@@ -321,6 +322,13 @@ export const AxleSpacingAndWeightsTable = ({
         case POLICY_CHECK_ID_TYPES.MINIMUM_TANDEM_STEER_AXLE_WEIGHT:
           return rowType === ASW_TABLE_ROW_TYPES.AXLE
             ? [POLICY_CHECK_ID_TYPES.MINIMUM_TANDEM_STEER_AXLE_WEIGHT]
+            : [];
+
+        case POLICY_CHECK_ID_TYPES.PICKER_TRUCK_TRACTOR_WEIGHT_RESTRICTIONS:
+          return rowType === ASW_TABLE_ROW_TYPES.AXLE
+            ? [
+                POLICY_CHECK_ID_TYPES.PICKER_TRUCK_TRACTOR_WEIGHT_RESTRICTIONS,
+              ]
             : [];
 
         case POLICY_CHECK_ID_TYPES.NUMBER_OF_WHEELS_PER_AXLE:

--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleUnitRow.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleUnitRow.tsx
@@ -106,6 +106,9 @@ export const AxleUnitRow = ({
             ] ||
             axleCalculationFailure[
               POLICY_CHECK_ID_TYPES.MINIMUM_TANDEM_STEER_AXLE_WEIGHT
+            ] ||
+            axleCalculationFailure[
+              POLICY_CHECK_ID_TYPES.PICKER_TRUCK_TRACTOR_WEIGHT_RESTRICTIONS
             ],
         );
 

--- a/frontend/src/features/permits/types/AxleCalculationResult.ts
+++ b/frontend/src/features/permits/types/AxleCalculationResult.ts
@@ -17,6 +17,8 @@ export const POLICY_CHECK_ID_TYPES = {
   MINIMUM_TANDEM_STEER_AXLE_WEIGHT: "minimum-tandem-steer-axle-weight",
   NUMBER_OF_AXLES: "number-of-axles",
   NUMBER_OF_WHEELS_PER_AXLE: "number-of-wheels",
+  PICKER_TRUCK_TRACTOR_WEIGHT_RESTRICTIONS:
+    "picker-truck-tractor-weight-restrictions",
   TRUCK_TRACTOR_WHEELBASE: "truck-tractor-wheelbase",
 } as const;
 


### PR DESCRIPTION
This is enabling the PR here: https://github.com/bcgov/onroutebc-policy-engine/pull/109

<img width="2226" height="1292" alt="image" src="https://github.com/user-attachments/assets/47031aec-88a1-4ceb-abb8-45c6470be24a" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2303-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2303-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2303-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2303-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2303-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2303-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)