### PR TITLE
ORV2-5725 - FE: STOW ASW table fields are not highlighted on failed evaluation

### DIFF
--- a/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleUnitRow.tsx
+++ b/frontend/src/features/permits/pages/Application/components/form/axleSpacingAndWeightsSection/components/AxleUnitRow.tsx
@@ -106,7 +106,8 @@ export const AxleUnitRow = ({
             ] ||
             axleCalculationFailure[
               POLICY_CHECK_ID_TYPES.MINIMUM_TANDEM_STEER_AXLE_WEIGHT
-            ],
+            ] ||
+            axleCalculationFailure[POLICY_CHECK_ID_TYPES.MAX_TIRE_LOAD],
         );
 
         return (
@@ -203,7 +204,13 @@ export const AxleUnitRow = ({
                 <NumberInput
                   classes={{ root: "table__input-container" }}
                   inputProps={{
-                    className: "table__input",
+                    className: `table__input ${
+                      axleCalculationFailure[
+                        POLICY_CHECK_ID_TYPES.NUMBER_OF_WHEELS_PER_AXLE
+                      ]
+                        ? "table__input--fail"
+                        : ""
+                    }`,
                     value: getDefaultRequiredVal(null, axleUnit?.numberOfTires),
                     onBlur: ({ target: { value } }) => {
                       updateAxleUnit(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

add input highlighting for max tire load and number of wheels per axle failures

Fixes[#ORV2-5725](https://moti-imb.atlassian.net/browse/ORV2-5725?atlOrigin=eyJpIjoiMjNmNzE1ZjYyZjdmNDQ2Y2I2ZDgxMGM1M2Q4NmRmYjYiLCJwIjoiaiJ9)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2304-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2304-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2304-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2304-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2304-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2304-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)