### PR TITLE
feat: Add Amend and Void/Revoke to Expired Permits and Search

### DIFF
--- a/frontend/src/features/idir/search/components/IDIRPermitSearchResults.tsx
+++ b/frontend/src/features/idir/search/components/IDIRPermitSearchResults.tsx
@@ -221,7 +221,7 @@ export const IDIRPermitSearchResults = memo(
       },
       renderRowActions: useCallback(
         ({ row }: { row: MRT_Row<PermitListItem> }) => {
-          const isInactive =
+          const isPermitInactiveOrExpired =
             hasPermitExpired(row.original.expiryDate) ||
             isPermitInactive(row.original.permitStatus);
 
@@ -236,7 +236,9 @@ export const IDIRPermitSearchResults = memo(
             return (
               <Box className="idir-search-results__row-actions">
                 <PermitRowOptions
-                  isPermitInactive={isInactive}
+                  isPermitInactiveOrExpired={isPermitInactiveOrExpired}
+                  permitStatus={row.original.permitStatus}
+                  permitApprovalSource={row.original.permitApprovalSource}
                   permitNumber={row.original.permitNumber}
                   permitId={row.original.permitId}
                   companyId={row.original.companyId}

--- a/frontend/src/features/permits/components/permit-list/BasePermitList.tsx
+++ b/frontend/src/features/permits/components/permit-list/BasePermitList.tsx
@@ -228,7 +228,7 @@ export const BasePermitList = ({
     renderEmptyRowsFallback: () => <NoRecordsFound />,
     renderRowActions: useCallback(
       ({ row }: { row: MRT_Row<PermitListItem> }) => {
-        const isInactive =
+        const isPermitInactiveOrExpired =
           hasPermitExpired(row.original.expiryDate) ||
           isPermitInactive(row.original.permitStatus);
 
@@ -242,7 +242,9 @@ export const BasePermitList = ({
         return (
           <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
             <PermitRowOptions
-              isPermitInactive={isInactive}
+              isPermitInactiveOrExpired={isPermitInactiveOrExpired}
+              permitStatus={row.original.permitStatus}
+              permitApprovalSource={row.original.permitApprovalSource}
               permitNumber={row.original.permitNumber}
               permitId={row.original.permitId}
               companyId={row.original.companyId}

--- a/frontend/src/features/permits/components/permit-list/PermitRowOptions.tsx
+++ b/frontend/src/features/permits/components/permit-list/PermitRowOptions.tsx
@@ -13,13 +13,20 @@ import { UnfinishedAmendModal } from "../../pages/Amend/components/modal/Unfinis
 import { getDefaultRequiredVal } from "../../../../common/helpers/util";
 import { PERMIT_ACTION_ORIGINS, PermitActionOrigin } from "../../types/PermitActionOrigin";
 import { PERMIT_ACTION_TYPES } from "../../types/PermitActionType";
-import { getPermitActionOptions } from "../../helpers/getPermitActionOptions";
+import {
+  getPermitRowActionOptions,
+  PermitActionPermissions,
+} from "../../helpers/getPermitActionOptions";
 import { useSetCompanyHandler } from "../../../idir/search/helpers/useSetCompanyHandler";
 import { useCompanyInfoDetailsQuery } from "../../../manageProfile/apiManager/hooks";
+import { PermitStatus } from "../../types/PermitStatus";
+import { PermitApprovalSource } from "../../types/PermitApprovalSource";
 
 export const PermitRowOptions = ({
   permitId,
-  isPermitInactive,
+  isPermitInactiveOrExpired,
+  permitStatus,
+  permitApprovalSource,
   permitNumber,
   companyId,
   permitActionOrigin,
@@ -27,20 +34,15 @@ export const PermitRowOptions = ({
 }: {
   permitId: string;
   // Is the permit inactive (voided/superseded/revoked) or expired?
-  isPermitInactive: boolean;
+  isPermitInactiveOrExpired: boolean;
+  permitStatus: PermitStatus;
+  permitApprovalSource: PermitApprovalSource;
   permitNumber: string;
   companyId: number;
   // The application location from where the permit action (amend/void/revoke/copy) originated
   permitActionOrigin: PermitActionOrigin;
   // Object containing the relevant permission matrix checks for each action
-  permissions: {
-    canResendPermit: boolean;
-    canViewPermitReceipt: boolean;
-    canViewExpiredPermitReceipt: boolean;
-    canAmendPermit: boolean;
-    canVoidPermit: boolean;
-    canCopyPermit: boolean;
-  };
+  permissions: PermitActionPermissions;
 }) => {
   const [openResendDialog, setOpenResendDialog] = useState<boolean>(false);
   const navigate = useNavigate();
@@ -146,45 +148,18 @@ export const PermitRowOptions = ({
     }
   };
 
-  const {
-    canResendPermit,
-    canViewPermitReceipt,
-    canViewExpiredPermitReceipt,
-    canAmendPermit,
-    canVoidPermit,
-    canCopyPermit,
-  } = permissions;
-
-  const permitActions = [
-    {
-      action: PERMIT_ACTION_TYPES.COPY,
-      isAuthorized: () => canCopyPermit,
-    },
-    {
-      action: PERMIT_ACTION_TYPES.RESEND,
-      isAuthorized: () => canResendPermit,
-    },
-    {
-      action: PERMIT_ACTION_TYPES.VIEW_RECEIPT,
-      isAuthorized: (isExpired: boolean) =>
-        (!isExpired && canViewPermitReceipt) ||
-        (isExpired && canViewExpiredPermitReceipt),
-    },
-    {
-      action: PERMIT_ACTION_TYPES.AMEND,
-      isAuthorized: (isExpired: boolean) => !isExpired && canAmendPermit,
-    },
-    {
-      action: PERMIT_ACTION_TYPES.VOID_REVOKE,
-      isAuthorized: (isExpired: boolean) => !isExpired && canVoidPermit,
-    },
-  ];
-
   return (
     <>
       <OnRouteBCTableRowActions
         onSelectOption={onSelectOption}
-        options={getPermitActionOptions(permitActions, isPermitInactive)}
+        options={
+          getPermitRowActionOptions({
+            isPermitInactiveOrExpired,
+            permitStatus,
+            permitApprovalSource,
+            permissions,
+          })
+        }
         key={`idir-search-row-${permitNumber}`}
       />
 

--- a/frontend/src/features/permits/helpers/getPermitActionOptions.ts
+++ b/frontend/src/features/permits/helpers/getPermitActionOptions.ts
@@ -1,22 +1,86 @@
-import { PermitActionType } from "../types/PermitActionType";
+import {
+  PERMIT_ACTION_TYPES,
+  PermitActionType,
+} from "../types/PermitActionType";
+import { PermitApprovalSource } from "../types/PermitApprovalSource";
+import { PermitStatus } from "../types/PermitStatus";
 import { getPermitActionLabel } from "./getPermitActionLabel";
+import { isPermitEligibleForAmendOrRevokeActions } from "./isPermitEligibleForAmendOrRevokeActions";
+
+export interface PermitActionPermissions {
+  canResendPermit: boolean;
+  canViewPermitReceipt: boolean;
+  canViewExpiredPermitReceipt: boolean;
+  canAmendPermit: boolean;
+  canVoidPermit: boolean;
+  canCopyPermit: boolean;
+}
 
 /**
  * Returns options for the row actions.
- * @param isExpired Has the permit expired?
  * @returns Action options that can be performed for the permit.
  */
 export const getPermitActionOptions = (
   permitActions: {
     action: PermitActionType;
-    isAuthorized: (isAuthorized: boolean) => boolean;
+    isAuthorized: boolean;
   }[],
-  isExpired: boolean,
 ) => {
   return permitActions
-    .filter((action) => action.isAuthorized(isExpired))
+    .filter((action) => action.isAuthorized)
     .map(({ action }) => ({
       label: getPermitActionLabel(action),
       value: action,
     }));
+};
+
+export const getPermitRowActionOptions = ({
+  isPermitInactiveOrExpired,
+  permitStatus,
+  permitApprovalSource,
+  permissions,
+}: {
+  isPermitInactiveOrExpired: boolean;
+  permitStatus: PermitStatus;
+  permitApprovalSource: PermitApprovalSource;
+  permissions: PermitActionPermissions;
+}) => {
+  const {
+    canResendPermit,
+    canViewPermitReceipt,
+    canViewExpiredPermitReceipt,
+    canAmendPermit,
+    canVoidPermit,
+    canCopyPermit,
+  } = permissions;
+
+  const isEligibleForAmendOrRevoke = isPermitEligibleForAmendOrRevokeActions(
+    permitStatus,
+    permitApprovalSource,
+  );
+
+  return getPermitActionOptions([
+    {
+      action: PERMIT_ACTION_TYPES.COPY,
+      isAuthorized: canCopyPermit,
+    },
+    {
+      action: PERMIT_ACTION_TYPES.RESEND,
+      isAuthorized: canResendPermit,
+    },
+    {
+      action: PERMIT_ACTION_TYPES.VIEW_RECEIPT,
+      isAuthorized:
+        (!isPermitInactiveOrExpired && canViewPermitReceipt) ||
+        (isPermitInactiveOrExpired && canViewExpiredPermitReceipt),
+    },
+    {
+      action: PERMIT_ACTION_TYPES.AMEND,
+      isAuthorized: isEligibleForAmendOrRevoke && canAmendPermit,
+    },
+    {
+      action: PERMIT_ACTION_TYPES.VOID_REVOKE,
+      isAuthorized: isEligibleForAmendOrRevoke && canVoidPermit,
+    },
+  ]);
 };

--- a/frontend/src/features/permits/helpers/getPermitTabForActionOrigin.ts
+++ b/frontend/src/features/permits/helpers/getPermitTabForActionOrigin.ts
@@ -1,0 +1,23 @@
+import {
+  PERMIT_ACTION_ORIGINS,
+  PermitActionOrigin,
+} from "../types/PermitActionOrigin";
+import { PERMIT_TABS } from "../types/PermitTabs";
+
+/**
+ * Maps a permit action's starting location to the company permit-list tab
+ * that the workflow should return to.
+ */
+export const getPermitTabForActionOrigin = (
+  permitActionOrigin?: PermitActionOrigin,
+) => {
+  if (permitActionOrigin === PERMIT_ACTION_ORIGINS.ACTIVE_PERMITS) {
+    return PERMIT_TABS.ACTIVE_PERMITS;
+  }
+
+  if (permitActionOrigin === PERMIT_ACTION_ORIGINS.EXPIRED_PERMITS) {
+    return PERMIT_TABS.EXPIRED_PERMITS;
+  }
+
+  return undefined;
+};

--- a/frontend/src/features/permits/helpers/isPermitEligibleForAmendOrRevokeActions.ts
+++ b/frontend/src/features/permits/helpers/isPermitEligibleForAmendOrRevokeActions.ts
@@ -1,0 +1,20 @@
+import {
+  PERMIT_APPROVAL_SOURCES,
+  PermitApprovalSource,
+} from "../types/PermitApprovalSource";
+import { PERMIT_STATUSES, PermitStatus } from "../types/PermitStatus";
+
+/**
+ * Centralizes migrated-permit detection and the eligibility shared by Amend
+ * and Void/Revoke menus and their direct-entry workflow guards.
+ */
+export const isMigratedPermit = (
+  permitApprovalSource?: PermitApprovalSource | null,
+) => permitApprovalSource === PERMIT_APPROVAL_SOURCES.TPS;
+
+export const isPermitEligibleForAmendOrRevokeActions = (
+  permitStatus: PermitStatus,
+  permitApprovalSource?: PermitApprovalSource | null,
+) =>
+  permitStatus === PERMIT_STATUSES.ISSUED &&
+  !isMigratedPermit(permitApprovalSource);

--- a/frontend/src/features/permits/helpers/isPermitEligibleForAmendOrRevokeActions.ts
+++ b/frontend/src/features/permits/helpers/isPermitEligibleForAmendOrRevokeActions.ts
@@ -3,18 +3,19 @@ import {
   PermitApprovalSource,
 } from "../types/PermitApprovalSource";
 import { PERMIT_STATUSES, PermitStatus } from "../types/PermitStatus";
+import { Nullable } from "../../../common/types/common";
 
 /**
  * Centralizes migrated-permit detection and the eligibility shared by Amend
  * and Void/Revoke menus and their direct-entry workflow guards.
  */
 export const isMigratedPermit = (
-  permitApprovalSource?: PermitApprovalSource | null,
+  permitApprovalSource: Nullable<PermitApprovalSource>,
 ) => permitApprovalSource === PERMIT_APPROVAL_SOURCES.TPS;
 
 export const isPermitEligibleForAmendOrRevokeActions = (
   permitStatus: PermitStatus,
-  permitApprovalSource?: PermitApprovalSource | null,
+  permitApprovalSource: Nullable<PermitApprovalSource>,
 ) =>
   permitStatus === PERMIT_STATUSES.ISSUED &&
   !isMigratedPermit(permitApprovalSource);

--- a/frontend/src/features/permits/helpers/tests/getPermitActionOptions.test.ts
+++ b/frontend/src/features/permits/helpers/tests/getPermitActionOptions.test.ts
@@ -1,0 +1,88 @@
+import {
+  getPermitRowActionOptions,
+  PermitActionPermissions,
+} from "../getPermitActionOptions";
+import { PERMIT_ACTION_TYPES } from "../../types/PermitActionType";
+import { PERMIT_APPROVAL_SOURCES } from "../../types/PermitApprovalSource";
+import { PERMIT_STATUSES } from "../../types/PermitStatus";
+
+const allPermissions: PermitActionPermissions = {
+  canResendPermit: true,
+  canViewPermitReceipt: true,
+  canViewExpiredPermitReceipt: true,
+  canAmendPermit: true,
+  canVoidPermit: true,
+  canCopyPermit: true,
+};
+
+const getActionValues = (
+  options: ReturnType<typeof getPermitRowActionOptions>,
+) => options.map(({ value }) => value);
+
+describe("getPermitRowActionOptions", () => {
+  it("offers Amend and Void/Revoke for an eligible expired permit", () => {
+    const options = getPermitRowActionOptions({
+      isPermitInactiveOrExpired: true,
+      permitStatus: PERMIT_STATUSES.ISSUED,
+      permitApprovalSource: PERMIT_APPROVAL_SOURCES.PPC,
+      permissions: allPermissions,
+    });
+
+    expect(getActionValues(options)).toContain(PERMIT_ACTION_TYPES.AMEND);
+    expect(getActionValues(options)).toContain(PERMIT_ACTION_TYPES.VOID_REVOKE);
+  });
+
+  it.each([
+    [PERMIT_STATUSES.REVOKED, PERMIT_APPROVAL_SOURCES.PPC],
+    [PERMIT_STATUSES.VOIDED, PERMIT_APPROVAL_SOURCES.PPC],
+    [PERMIT_STATUSES.SUPERSEDED, PERMIT_APPROVAL_SOURCES.PPC],
+    [PERMIT_STATUSES.ISSUED, PERMIT_APPROVAL_SOURCES.TPS],
+  ] as const)(
+    "does not offer Amend or Void/Revoke for %s/%s permits",
+    (permitStatus, permitApprovalSource) => {
+      const options = getPermitRowActionOptions({
+        isPermitInactiveOrExpired: true,
+        permitStatus,
+        permitApprovalSource,
+        permissions: allPermissions,
+      });
+      const actionValues = getActionValues(options);
+
+      expect(actionValues).not.toContain(PERMIT_ACTION_TYPES.AMEND);
+      expect(actionValues).not.toContain(PERMIT_ACTION_TYPES.VOID_REVOKE);
+    },
+  );
+
+  it("applies Amend and Void/Revoke permissions independently", () => {
+    const options = getPermitRowActionOptions({
+      isPermitInactiveOrExpired: true,
+      permitStatus: PERMIT_STATUSES.ISSUED,
+      permitApprovalSource: PERMIT_APPROVAL_SOURCES.AUTO,
+      permissions: {
+        ...allPermissions,
+        canAmendPermit: false,
+      },
+    });
+    const actionValues = getActionValues(options);
+
+    expect(actionValues).not.toContain(PERMIT_ACTION_TYPES.AMEND);
+    expect(actionValues).toContain(PERMIT_ACTION_TYPES.VOID_REVOKE);
+  });
+
+  it("uses the expired receipt permission for inactive or expired permits", () => {
+    const options = getPermitRowActionOptions({
+      isPermitInactiveOrExpired: true,
+      permitStatus: PERMIT_STATUSES.REVOKED,
+      permitApprovalSource: PERMIT_APPROVAL_SOURCES.PPC,
+      permissions: {
+        ...allPermissions,
+        canViewPermitReceipt: false,
+        canViewExpiredPermitReceipt: true,
+      },
+    });
+
+    expect(getActionValues(options)).toContain(
+      PERMIT_ACTION_TYPES.VIEW_RECEIPT,
+    );
+  });
+});

--- a/frontend/src/features/permits/helpers/tests/getPermitTabForActionOrigin.test.ts
+++ b/frontend/src/features/permits/helpers/tests/getPermitTabForActionOrigin.test.ts
@@ -1,0 +1,24 @@
+import { getPermitTabForActionOrigin } from "../getPermitTabForActionOrigin";
+import { PERMIT_ACTION_ORIGINS } from "../../types/PermitActionOrigin";
+import { PERMIT_TABS } from "../../types/PermitTabs";
+
+describe("getPermitTabForActionOrigin", () => {
+  it("maps the Active Permits origin to the Active Permits tab", () => {
+    expect(
+      getPermitTabForActionOrigin(PERMIT_ACTION_ORIGINS.ACTIVE_PERMITS),
+    ).toBe(PERMIT_TABS.ACTIVE_PERMITS);
+  });
+
+  it("maps the Expired Permits origin to the Expired Permits tab", () => {
+    expect(
+      getPermitTabForActionOrigin(PERMIT_ACTION_ORIGINS.EXPIRED_PERMITS),
+    ).toBe(PERMIT_TABS.EXPIRED_PERMITS);
+  });
+
+  it.each([PERMIT_ACTION_ORIGINS.GLOBAL_SEARCH, PERMIT_ACTION_ORIGINS.AIP])(
+    "does not map the %s origin to a permit-list tab",
+    (origin) => {
+      expect(getPermitTabForActionOrigin(origin)).toBeUndefined();
+    },
+  );
+});

--- a/frontend/src/features/permits/helpers/tests/isPermitEligibleForAmendOrRevokeActions.test.ts
+++ b/frontend/src/features/permits/helpers/tests/isPermitEligibleForAmendOrRevokeActions.test.ts
@@ -1,0 +1,39 @@
+import { isPermitEligibleForAmendOrRevokeActions } from "../isPermitEligibleForAmendOrRevokeActions";
+import { PERMIT_APPROVAL_SOURCES } from "../../types/PermitApprovalSource";
+import { PERMIT_STATUSES } from "../../types/PermitStatus";
+
+describe("isPermitEligibleForAmendOrRevokeActions", () => {
+  it.each([PERMIT_APPROVAL_SOURCES.AUTO, PERMIT_APPROVAL_SOURCES.PPC] as const)(
+    "allows issued %s permits",
+    (permitApprovalSource) => {
+      expect(
+        isPermitEligibleForAmendOrRevokeActions(
+          PERMIT_STATUSES.ISSUED,
+          permitApprovalSource,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("rejects issued TPS permits", () => {
+    expect(
+      isPermitEligibleForAmendOrRevokeActions(
+        PERMIT_STATUSES.ISSUED,
+        PERMIT_APPROVAL_SOURCES.TPS,
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    PERMIT_STATUSES.REVOKED,
+    PERMIT_STATUSES.VOIDED,
+    PERMIT_STATUSES.SUPERSEDED,
+  ] as const)("rejects %s permits", (permitStatus) => {
+    expect(
+      isPermitEligibleForAmendOrRevokeActions(
+        permitStatus,
+        PERMIT_APPROVAL_SOURCES.PPC,
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/features/permits/pages/Amend/AmendPermit.tsx
+++ b/frontend/src/features/permits/pages/Amend/AmendPermit.tsx
@@ -8,7 +8,7 @@ import {
 import { Box } from "@mui/material";
 
 import { Permit } from "../../types/permit";
-import { PERMIT_STATUSES, isPermitInactive } from "../../types/PermitStatus";
+import { isPermitInactive } from "../../types/PermitStatus";
 import { Banner } from "../../../../common/components/dashboard/components/banner/Banner";
 import { useMultiStepForm } from "../../hooks/useMultiStepForm";
 import { AmendPermitContext } from "./context/AmendPermitContext";
@@ -38,10 +38,13 @@ import {
   SEARCH_BY_FILTERS,
   SEARCH_ENTITIES,
 } from "../../../idir/search/types/types";
-import { PERMIT_TABS } from "../../types/PermitTabs";
 import { USER_ROLE } from "../../../../common/authentication/types";
 import OnRouteBCContext from "../../../../common/authentication/OnRouteBCContext";
-import { PERMIT_ACTION_ORIGINS } from "../../types/PermitActionOrigin";
+import { getPermitTabForActionOrigin } from "../../helpers/getPermitTabForActionOrigin";
+import {
+  isMigratedPermit,
+  isPermitEligibleForAmendOrRevokeActions,
+} from "../../helpers/isPermitEligibleForAmendOrRevokeActions";
 
 export const AMEND_PERMIT_STEPS = {
   Amend: "Amend",
@@ -64,14 +67,18 @@ const displayHeaderText = (stepKey: AmendPermitStep) => {
 };
 
 /**
- * Determine if a permit is amendable (ie. if it's ISSUED or is active)
+ * Determine if a permit is eligible for amendment.
  * @param permit Permit to amend
  * @returns whether or not the permit is amendable
  */
 const isAmendable = (permit: Permit) => {
   return (
-    permit.permitStatus === PERMIT_STATUSES.ISSUED ||
-    (!isPermitInactive(permit.permitStatus) &&
+    isPermitEligibleForAmendOrRevokeActions(
+      permit.permitStatus,
+      permit.permitApprovalSource,
+    ) ||
+    (!isMigratedPermit(permit.permitApprovalSource) &&
+      !isPermitInactive(permit.permitStatus) &&
       !hasPermitExpired(permit.permitData.expiryDate))
   );
 };
@@ -138,27 +145,33 @@ export const AmendPermit = () => {
   };
   const fullSearchRoute = `${searchRoute}${getBasePermitNumber()}`;
 
-  const goHome = () =>
-    stateFromNavigation.permitActionOrigin ===
-    PERMIT_ACTION_ORIGINS.ACTIVE_PERMITS
-      ? navigate(APPLICATIONS_ROUTES.BASE, {
-          state: {
-            selectedTab: PERMIT_TABS.ACTIVE_PERMITS,
-          },
-        })
-      : // return to global permit search results
-        navigate(-1);
+  const originPermitTab = getPermitTabForActionOrigin(
+    stateFromNavigation.permitActionOrigin,
+  );
 
-  const goHomeSuccess = () =>
-    stateFromNavigation.permitActionOrigin ===
-    PERMIT_ACTION_ORIGINS.ACTIVE_PERMITS
-      ? navigate(APPLICATIONS_ROUTES.BASE, {
-          state: {
-            selectedTab: PERMIT_TABS.ACTIVE_PERMITS,
-          },
-        })
-      : // return to global permit search results
-        navigate(fullSearchRoute);
+  const goHome = () => {
+    if (originPermitTab) {
+      navigate(APPLICATIONS_ROUTES.BASE, {
+        state: { selectedTab: originPermitTab },
+      });
+      return;
+    }
+
+    // Return to global permit search results.
+    navigate(-1);
+  };
+
+  const goHomeSuccess = () => {
+    if (originPermitTab) {
+      navigate(APPLICATIONS_ROUTES.BASE, {
+        state: { selectedTab: originPermitTab },
+      });
+      return;
+    }
+
+    // Return to global permit search results.
+    navigate(fullSearchRoute);
+  };
 
   const allLinks = [
     {

--- a/frontend/src/features/permits/pages/Void/VoidPermit.tsx
+++ b/frontend/src/features/permits/pages/Void/VoidPermit.tsx
@@ -18,27 +18,25 @@ import {
 } from "../../../../routes/constants";
 import { VoidPermitFormData } from "./types/VoidPermit";
 import { FinishVoid } from "./FinishVoid";
-import { isPermitInactive } from "../../types/PermitStatus";
 import { Permit } from "../../types/permit";
 import {
   applyWhenNotNullable,
   getDefaultRequiredVal,
 } from "../../../../common/helpers/util";
 import { Breadcrumb } from "../../../../common/components/breadcrumb/Breadcrumb";
-import { hasPermitExpired } from "../../helpers/permitState";
 import { SEARCH_BY_FILTERS, SEARCH_ENTITIES } from "../../../idir/search/types/types";
-import { PERMIT_TABS } from "../../types/PermitTabs";
 import { usePermissionMatrix } from "../../../../common/authentication/PermissionMatrix";
-import { PERMIT_ACTION_ORIGINS } from "../../types/PermitActionOrigin";
+import { getPermitTabForActionOrigin } from "../../helpers/getPermitTabForActionOrigin";
+import { isPermitEligibleForAmendOrRevokeActions } from "../../helpers/isPermitEligibleForAmendOrRevokeActions";
 
 const searchRoute =
   `${IDIR_ROUTES.SEARCH_RESULTS}?searchEntity=${SEARCH_ENTITIES.PERMIT}` +
   `&searchByFilter=${SEARCH_BY_FILTERS.PERMIT_NUMBER}`;
 
 const isVoidable = (permit: Permit) => {
-  return (
-    !isPermitInactive(permit.permitStatus) &&
-    !hasPermitExpired(permit.permitData.expiryDate)
+  return isPermitEligibleForAmendOrRevokeActions(
+    permit.permitStatus,
+    permit.permitApprovalSource,
   );
 };
 
@@ -87,25 +85,31 @@ export const VoidPermit = () => {
   };
 
   const fullSearchRoute = `${searchRoute}&searchString=${getBasePermitNumber()}`;
-  const goHome = () =>
-    permitActionOrigin === PERMIT_ACTION_ORIGINS.ACTIVE_PERMITS
-      ? navigate(APPLICATIONS_ROUTES.BASE, {
-          state: {
-            selectedTab: PERMIT_TABS.ACTIVE_PERMITS,
-          },
-        })
-      : // return to global permit search results
-        navigate(-1);
+  const originPermitTab = getPermitTabForActionOrigin(permitActionOrigin);
 
-  const goHomeSuccess = () =>
-    permitActionOrigin === PERMIT_ACTION_ORIGINS.ACTIVE_PERMITS
-      ? navigate(APPLICATIONS_ROUTES.BASE, {
-          state: {
-            selectedTab: PERMIT_TABS.ACTIVE_PERMITS,
-          },
-        })
-      : // return to global permit search results
-        navigate(fullSearchRoute);
+  const goHome = () => {
+    if (originPermitTab) {
+      navigate(APPLICATIONS_ROUTES.BASE, {
+        state: { selectedTab: originPermitTab },
+      });
+      return;
+    }
+
+    // Return to global permit search results.
+    navigate(-1);
+  };
+
+  const goHomeSuccess = () => {
+    if (originPermitTab) {
+      navigate(APPLICATIONS_ROUTES.BASE, {
+        state: { selectedTab: originPermitTab },
+      });
+      return;
+    }
+
+    // Return to global permit search results.
+    navigate(fullSearchRoute);
+  };
   const handleFail = () => navigate(ERROR_ROUTES.UNEXPECTED);
 
   const getLinks = () =>


### PR DESCRIPTION
Had to modify PermitRowOptions, which is the component which does most of heavy lifting, passing in permitStatus and permitApprovalSource. (We use source to detect if it's a TPS migration). We put a lot of our logic in getPermitRowActionOptions.

I renamed some variables, like `isPermitInactive` to be more accurate of what they actually meausre now, also Expired etc.

I also added UI route guards here, to make sure even if someone navigates to page directly it won't work to bypass our UI.

Most of my 'shared' work here is in getPermitActionOptions


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2325-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2325-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2325-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2325-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2325-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2325-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)