### PR TITLE
fix: Voiding Expired permits Fee Summary now matches Active exactly

### DIFF
--- a/frontend/src/features/permits/helpers/feeSummary.ts
+++ b/frontend/src/features/permits/helpers/feeSummary.ts
@@ -3,10 +3,8 @@ import { Policy } from "onroute-policy-engine";
 import { PermitData } from "../types/PermitData";
 import { PermitHistory } from "../types/PermitHistory";
 import { TRANSACTION_TYPES, TransactionType } from "../types/payment";
-import { Permit } from "../types/permit";
 import { isValidTransaction } from "./payment";
 import { Nullable } from "../../../common/types/common";
-import { PERMIT_STATES, getPermitState } from "./permitState";
 import { PermitType } from "../types/PermitType";
 import { ReplaceDayjsWithString } from "../types/utility";
 import {
@@ -118,19 +116,10 @@ export const isZeroAmount = (amount: number) => {
 
 /**
  * Calculates the amount that can be refunded for voiding the permit.
- * @param permit Permit to void
  * @param permitHistory List of history objects that make up the history of a permit and its transactions
  * @returns Amount that can be refunded as a result of the void operation
  */
-export const calculateAmountForVoid = (
-  permit: Permit,
-  transactionHistory: PermitHistory[],
-) => {
-  const permitState = getPermitState(permit);
-  if (permitState === PERMIT_STATES.EXPIRED) {
-    return 0;
-  }
-
+export const calculateAmountForVoid = (transactionHistory: PermitHistory[]) => {
   const netPaid = calculateNetAmount(transactionHistory);
   if (isZeroAmount(netPaid)) return 0; // If existing net paid is $0 (eg. no-fee permits), then refund nothing
 

--- a/frontend/src/features/permits/helpers/tests/feeSummary.test.ts
+++ b/frontend/src/features/permits/helpers/tests/feeSummary.test.ts
@@ -1,0 +1,73 @@
+import { PAYMENT_METHOD_TYPE_CODE } from "../../../../common/types/paymentMethods";
+import { calculateAmountForVoid, calculateNetAmount } from "../feeSummary";
+import { PermitHistory } from "../../types/PermitHistory";
+import { TRANSACTION_TYPES } from "../../types/payment";
+
+const getPermitHistory = (
+  overrides: Partial<PermitHistory> = {},
+): PermitHistory => ({
+  permitNumber: "P2-00000001-001",
+  comment: null,
+  commentUsername: "Test User",
+  transactionAmount: 15,
+  transactionOrderNumber: "TEST-ORDER",
+  pgTransactionId: "12345",
+  pgPaymentMethod: "CC",
+  paymentCardTypeCode: "VI",
+  paymentMethodTypeCode: PAYMENT_METHOD_TYPE_CODE.WEB,
+  transactionTypeId: TRANSACTION_TYPES.P,
+  permitId: 1,
+  transactionSubmitDate: "2026-07-01T00:00:00.000Z",
+  pgApproved: 1,
+  creditAccountMismatch: false,
+  creditAccountStatusType: null,
+  ...overrides,
+});
+
+describe("feeSummary", () => {
+  describe("calculateAmountForVoid", () => {
+    it("refunds the full current permit value when voiding", () => {
+      const transactionHistory = [getPermitHistory()];
+
+      const currentPermitValue = calculateNetAmount(transactionHistory);
+      const amountToRefund = -calculateAmountForVoid(transactionHistory);
+      const newPermitValue = currentPermitValue + amountToRefund;
+
+      expect(currentPermitValue).toBe(15);
+      expect(newPermitValue).toBe(0);
+      expect(amountToRefund).toBe(-15);
+    });
+
+    it("ignores failed web payment attempts", () => {
+      const transactionHistory = [
+        getPermitHistory({ pgApproved: 0, transactionAmount: 30 }),
+        getPermitHistory(),
+      ];
+
+      expect(calculateAmountForVoid(transactionHistory)).toBe(15);
+    });
+
+    it("refunds the remaining net value after a previous refund", () => {
+      const transactionHistory = [
+        getPermitHistory({ transactionAmount: 20 }),
+        getPermitHistory({
+          transactionAmount: 5,
+          transactionTypeId: TRANSACTION_TYPES.R,
+        }),
+      ];
+
+      expect(calculateAmountForVoid(transactionHistory)).toBe(15);
+    });
+
+    it("returns zero for a no-fee or fully refunded permit", () => {
+      const noFeeHistory = [getPermitHistory({ transactionAmount: 0 })];
+      const fullyRefundedHistory = [
+        getPermitHistory(),
+        getPermitHistory({ transactionTypeId: TRANSACTION_TYPES.R }),
+      ];
+
+      expect(calculateAmountForVoid(noFeeHistory)).toBe(0);
+      expect(calculateAmountForVoid(fullyRefundedHistory)).toBe(0);
+    });
+  });
+});

--- a/frontend/src/features/permits/pages/Void/FinishVoid.tsx
+++ b/frontend/src/features/permits/pages/Void/FinishVoid.tsx
@@ -47,7 +47,7 @@ export const FinishVoid = () => {
   const amountToRefund =
     !permit || transactionHistory.length === 0
       ? 0
-      : -1 * calculateAmountForVoid(permit, transactionHistory);
+      : -1 * calculateAmountForVoid(transactionHistory);
 
   const { mutation: voidPermitMutation, voidResults } = useVoidOrRevokePermit();
 

--- a/frontend/src/features/permits/pages/Void/components/VoidPermitForm.tsx
+++ b/frontend/src/features/permits/pages/Void/components/VoidPermitForm.tsx
@@ -71,7 +71,7 @@ export const VoidPermitForm = () => {
   const amountToRefund =
     !permit || transactionHistory.length === 0
       ? 0
-      : -1 * calculateAmountForVoid(permit, transactionHistory);
+      : -1 * calculateAmountForVoid(transactionHistory);
 
   const currentPermitValue = calculateNetAmount(transactionHistory);
 


### PR DESCRIPTION
This was requested change after PO was testing work for a88e6ff4d270e8df73d0caf8e4f2dbf3055707a3

The problem is that Voiding an Expired permit had an extra check to disable refund logic, which was breaking our view. This extra code was added 2yr ago, much before we had new requirement to Void Expired permits. So we just removed that, updated function calls, and added some tests.

Isn't it nice when you can fix code just by deleting it? :)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2327-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2327-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2327-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2327-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2327-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2327-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)