### PR TITLE
fix: Fix STOW validations stopping STOS and other form submission.

### DIFF
--- a/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
+++ b/frontend/src/features/permits/pages/Amend/components/AmendPermitForm.tsx
@@ -226,6 +226,7 @@ export const AmendPermitForm = () => {
     );
     // If any ASW inputs are empty, do not continue to policy validation
     if (
+      data.permitType === PERMIT_TYPES.STOW &&
       !validateAxleConfiguration(mergeInteraxleSpacing(axleConfiguration, 1))
     ) {
       setAxleCalculationResultsFromValidation(undefined);

--- a/frontend/src/features/permits/pages/Application/ApplicationForm.test.tsx
+++ b/frontend/src/features/permits/pages/Application/ApplicationForm.test.tsx
@@ -16,7 +16,7 @@ import {
   POLICY_CHECK_ID_TYPES,
   AxleCalculationResult,
 } from "../../types/AxleCalculationResult";
-import { PERMIT_TYPES } from "../../types/PermitType";
+import { PERMIT_TYPES, PermitType } from "../../types/PermitType";
 import { ApplicationForm } from "./ApplicationForm";
 
 const mocks = vi.hoisted(() => ({
@@ -128,8 +128,8 @@ const validAxleConfiguration = [
   },
 ];
 
-const createFormData = () => {
-  const formData = getDefaultValues(PERMIT_TYPES.STOW, undefined);
+const createFormData = (permitType: PermitType = PERMIT_TYPES.STOW) => {
+  const formData = getDefaultValues(permitType, undefined);
   formData.permitData.vehicleConfiguration = {
     ...formData.permitData.vehicleConfiguration,
     axleConfiguration: validAxleConfiguration,
@@ -137,7 +137,21 @@ const createFormData = () => {
   return formData;
 };
 
-const renderApplicationForm = (isStaff = false) => {
+const mockFormData = (formData: ReturnType<typeof createFormData>) => {
+  vi.mocked(useInitApplicationFormData).mockReturnValue({
+    initialFormData: formData,
+    currentFormData: formData,
+    formMethods: {
+      handleSubmit: (handler: (data: typeof formData) => Promise<void>) => () =>
+        handler(formData),
+    },
+  } as ReturnType<typeof useInitApplicationFormData>);
+};
+
+const renderApplicationForm = (
+  isStaff = false,
+  permitType: PermitType = PERMIT_TYPES.STOW,
+) => {
   const contextValue = isStaff
     ? {
         idirUserDetails: {
@@ -158,7 +172,7 @@ const renderApplicationForm = (isStaff = false) => {
 
   return render(
     <ApplicationForm
-      permitType={PERMIT_TYPES.STOW}
+      permitType={permitType}
       companyId={1}
       applicationStepContext={APPLICATION_STEP_CONTEXTS.APPLY}
       isCopiedApplication={false}
@@ -172,15 +186,7 @@ describe("ApplicationForm permit-not-required handling", () => {
     vi.clearAllMocks();
 
     const formData = createFormData();
-    vi.mocked(useInitApplicationFormData).mockReturnValue({
-      initialFormData: formData,
-      currentFormData: formData,
-      formMethods: {
-        handleSubmit:
-          (handler: (data: typeof formData) => Promise<void>) => () =>
-            handler(formData),
-      },
-    } as ReturnType<typeof useInitApplicationFormData>);
+    mockFormData(formData);
 
     mocks.handleSaveVehicle.mockResolvedValue({});
     mocks.saveApplication.mockResolvedValue(undefined);
@@ -265,5 +271,35 @@ describe("ApplicationForm permit-not-required handling", () => {
       }),
     ).not.toBeInTheDocument();
     consoleError.mockRestore();
+  });
+
+  it("continues STOS applications without requiring hidden ASW fields", async () => {
+    const user = userEvent.setup();
+    const formData = createFormData(PERMIT_TYPES.STOS);
+    formData.permitData.vehicleConfiguration = {
+      ...formData.permitData.vehicleConfiguration,
+      axleConfiguration: [
+        {
+          numberOfAxles: 1,
+          numberOfTires: null,
+          tireSize: 279,
+          axleSpread: null,
+          axleUnitWeight: null,
+          interaxleSpacing: null,
+        },
+      ],
+    };
+    mockFormData(formData);
+    mocks.policyValidate.mockResolvedValue({
+      violations: [],
+      axleCalculationResults: createAxleCalculationResults(),
+    });
+
+    renderApplicationForm(false, PERMIT_TYPES.STOS);
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(mocks.policyValidate).toHaveBeenCalledOnce();
+    expect(mocks.handleSaveVehicle).toHaveBeenCalledOnce();
+    expect(mocks.saveApplication).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
+++ b/frontend/src/features/permits/pages/Application/ApplicationForm.tsx
@@ -23,7 +23,7 @@ import {
   Nullable,
   ORBC_FORM_FEATURES,
 } from "../../../../common/types/common";
-import { PermitType } from "../../types/PermitType";
+import { PERMIT_TYPES, PermitType } from "../../types/PermitType";
 import { PermitVehicleDetails } from "../../types/PermitVehicleDetails";
 import { durationOptionsForPermitType } from "../../helpers/dateSelection";
 import { PAST_START_DATE_STATUSES } from "../../../../common/components/form/subFormComponents/CustomDatePicker";
@@ -277,6 +277,7 @@ export const ApplicationForm = ({
     );
     // If any ASW inputs are empty, do not continue to policy validation
     if (
+      data.permitType === PERMIT_TYPES.STOW &&
       !validateAxleConfiguration(mergeInteraxleSpacing(axleConfiguration, 1))
     ) {
       setAxleCalculationResultsFromValidation(undefined);


### PR DESCRIPTION
This fixes a bug Nicole and I found that stops STOS form submissions, as well as basically other non-STOW forms. Whoops! Relevant commit: https://github.com/bcgov/onroutebc/commit/f33b6552

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://onroutebc-2344-frontend.apps.gold.devops.gov.bc.ca)
- [Vehicles](https://onroutebc-2344-vehicles.apps.gold.devops.gov.bc.ca/api)
- [Dops](https://onroutebc-2344-dops.apps.gold.devops.gov.bc.ca/api)
- [Policy](https://onroutebc-2344-policy.apps.gold.devops.gov.bc.ca/api)
- [Scheduler](https://onroutebc-2344-scheduler.apps.gold.devops.gov.bc.ca/api)
- [Public](https://onroutebc-2344-public.apps.gold.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/onroutebc/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/onroutebc/actions/workflows/merge.yml)